### PR TITLE
Updated 2023 Panthers, 1999-2012 Atlanta Falcons

### DIFF
--- a/data/all_playcallers.csv
+++ b/data/all_playcallers.csv
@@ -15,524 +15,6 @@ season,team,game_id,off_play_caller,def_play_caller
 2013,ARI,2013_15_ARI_TEN,Bruce Arians,Todd Bowles
 2013,ARI,2013_16_ARI_SEA,Bruce Arians,Todd Bowles
 2013,ARI,2013_17_SF_ARI,Bruce Arians,Todd Bowles
-2013,ATL,2013_01_ATL_NO,Dirk Koetter,Mike Nolan
-2013,ATL,2013_02_STL_ATL,Dirk Koetter,Mike Nolan
-2013,ATL,2013_03_ATL_MIA,Dirk Koetter,Mike Nolan
-2013,ATL,2013_04_NE_ATL,Dirk Koetter,Mike Nolan
-2013,ATL,2013_05_NYJ_ATL,Dirk Koetter,Mike Nolan
-2013,ATL,2013_07_TB_ATL,Dirk Koetter,Mike Nolan
-2013,ATL,2013_08_ATL_ARI,Dirk Koetter,Mike Nolan
-2013,ATL,2013_09_ATL_CAR,Dirk Koetter,Mike Nolan
-2013,ATL,2013_10_SEA_ATL,Dirk Koetter,Mike Nolan
-2013,ATL,2013_11_ATL_TB,Dirk Koetter,Mike Nolan
-2013,ATL,2013_12_NO_ATL,Dirk Koetter,Mike Nolan
-2013,ATL,2013_13_ATL_BUF,Dirk Koetter,Mike Nolan
-2013,ATL,2013_14_ATL_GB,Dirk Koetter,Mike Nolan
-2013,ATL,2013_15_WAS_ATL,Dirk Koetter,Mike Nolan
-2013,ATL,2013_16_ATL_SF,Dirk Koetter,Mike Nolan
-2013,ATL,2013_17_CAR_ATL,Dirk Koetter,Mike Nolan
-2013,BAL,2013_01_BAL_DEN,Jim Caldwell,Dean Pees
-2013,BAL,2013_02_CLE_BAL,Jim Caldwell,Dean Pees
-2013,BAL,2013_03_HOU_BAL,Jim Caldwell,Dean Pees
-2013,BAL,2013_04_BAL_BUF,Jim Caldwell,Dean Pees
-2013,BAL,2013_05_BAL_MIA,Jim Caldwell,Dean Pees
-2013,BAL,2013_06_GB_BAL,Jim Caldwell,Dean Pees
-2013,BAL,2013_07_BAL_PIT,Jim Caldwell,Dean Pees
-2013,BAL,2013_09_BAL_CLE,Jim Caldwell,Dean Pees
-2013,BAL,2013_10_CIN_BAL,Jim Caldwell,Dean Pees
-2013,BAL,2013_11_BAL_CHI,Jim Caldwell,Dean Pees
-2013,BAL,2013_12_NYJ_BAL,Jim Caldwell,Dean Pees
-2013,BAL,2013_13_PIT_BAL,Jim Caldwell,Dean Pees
-2013,BAL,2013_14_MIN_BAL,Jim Caldwell,Dean Pees
-2013,BAL,2013_15_BAL_DET,Jim Caldwell,Dean Pees
-2013,BAL,2013_16_NE_BAL,Jim Caldwell,Dean Pees
-2013,BAL,2013_17_BAL_CIN,Jim Caldwell,Dean Pees
-2013,BUF,2013_01_NE_BUF,Nathaniel Hackett,Mike Pettine
-2013,BUF,2013_02_CAR_BUF,Nathaniel Hackett,Mike Pettine
-2013,BUF,2013_03_BUF_NYJ,Nathaniel Hackett,Mike Pettine
-2013,BUF,2013_04_BAL_BUF,Nathaniel Hackett,Mike Pettine
-2013,BUF,2013_05_BUF_CLE,Nathaniel Hackett,Mike Pettine
-2013,BUF,2013_06_CIN_BUF,Nathaniel Hackett,Mike Pettine
-2013,BUF,2013_07_BUF_MIA,Nathaniel Hackett,Mike Pettine
-2013,BUF,2013_08_BUF_NO,Nathaniel Hackett,Mike Pettine
-2013,BUF,2013_09_KC_BUF,Nathaniel Hackett,Mike Pettine
-2013,BUF,2013_10_BUF_PIT,Nathaniel Hackett,Mike Pettine
-2013,BUF,2013_11_NYJ_BUF,Nathaniel Hackett,Mike Pettine
-2013,BUF,2013_13_ATL_BUF,Nathaniel Hackett,Mike Pettine
-2013,BUF,2013_14_BUF_TB,Nathaniel Hackett,Mike Pettine
-2013,BUF,2013_15_BUF_JAX,Nathaniel Hackett,Mike Pettine
-2013,BUF,2013_16_MIA_BUF,Nathaniel Hackett,Mike Pettine
-2013,BUF,2013_17_BUF_NE,Nathaniel Hackett,Mike Pettine
-2013,CAR,2013_01_SEA_CAR,Mike Shula,Sean McDermott
-2013,CAR,2013_02_CAR_BUF,Mike Shula,Sean McDermott
-2013,CAR,2013_03_NYG_CAR,Mike Shula,Sean McDermott
-2013,CAR,2013_05_CAR_ARI,Mike Shula,Sean McDermott
-2013,CAR,2013_06_CAR_MIN,Mike Shula,Sean McDermott
-2013,CAR,2013_07_STL_CAR,Mike Shula,Sean McDermott
-2013,CAR,2013_08_CAR_TB,Mike Shula,Sean McDermott
-2013,CAR,2013_09_ATL_CAR,Mike Shula,Sean McDermott
-2013,CAR,2013_10_CAR_SF,Mike Shula,Sean McDermott
-2013,CAR,2013_11_NE_CAR,Mike Shula,Sean McDermott
-2013,CAR,2013_12_CAR_MIA,Mike Shula,Sean McDermott
-2013,CAR,2013_13_TB_CAR,Mike Shula,Sean McDermott
-2013,CAR,2013_14_CAR_NO,Mike Shula,Sean McDermott
-2013,CAR,2013_15_NYJ_CAR,Mike Shula,Sean McDermott
-2013,CAR,2013_16_NO_CAR,Mike Shula,Sean McDermott
-2013,CAR,2013_17_CAR_ATL,Mike Shula,Sean McDermott
-2013,CAR,2013_19_SF_CAR,Mike Shula,Sean McDermott
-2013,CHI,2013_01_CIN_CHI,Marc Trestman,Mel Tucker
-2013,CHI,2013_02_MIN_CHI,Marc Trestman,Mel Tucker
-2013,CHI,2013_03_CHI_PIT,Marc Trestman,Mel Tucker
-2013,CHI,2013_04_CHI_DET,Marc Trestman,Mel Tucker
-2013,CHI,2013_05_NO_CHI,Marc Trestman,Mel Tucker
-2013,CHI,2013_06_NYG_CHI,Marc Trestman,Mel Tucker
-2013,CHI,2013_07_CHI_WAS,Marc Trestman,Mel Tucker
-2013,CHI,2013_09_CHI_GB,Marc Trestman,Mel Tucker
-2013,CHI,2013_10_DET_CHI,Marc Trestman,Mel Tucker
-2013,CHI,2013_11_BAL_CHI,Marc Trestman,Mel Tucker
-2013,CHI,2013_12_CHI_STL,Marc Trestman,Mel Tucker
-2013,CHI,2013_13_CHI_MIN,Marc Trestman,Mel Tucker
-2013,CHI,2013_14_DAL_CHI,Marc Trestman,Mel Tucker
-2013,CHI,2013_15_CHI_CLE,Marc Trestman,Mel Tucker
-2013,CHI,2013_16_CHI_PHI,Marc Trestman,Mel Tucker
-2013,CHI,2013_17_GB_CHI,Marc Trestman,Mel Tucker
-2013,CIN,2013_01_CIN_CHI,Jay Gruden,Mike Zimmer
-2013,CIN,2013_02_PIT_CIN,Jay Gruden,Mike Zimmer
-2013,CIN,2013_03_GB_CIN,Jay Gruden,Mike Zimmer
-2013,CIN,2013_04_CIN_CLE,Jay Gruden,Mike Zimmer
-2013,CIN,2013_05_NE_CIN,Jay Gruden,Mike Zimmer
-2013,CIN,2013_06_CIN_BUF,Jay Gruden,Mike Zimmer
-2013,CIN,2013_07_CIN_DET,Jay Gruden,Mike Zimmer
-2013,CIN,2013_08_NYJ_CIN,Jay Gruden,Mike Zimmer
-2013,CIN,2013_09_CIN_MIA,Jay Gruden,Mike Zimmer
-2013,CIN,2013_10_CIN_BAL,Jay Gruden,Mike Zimmer
-2013,CIN,2013_11_CLE_CIN,Jay Gruden,Mike Zimmer
-2013,CIN,2013_13_CIN_SD,Jay Gruden,Mike Zimmer
-2013,CIN,2013_14_IND_CIN,Jay Gruden,Mike Zimmer
-2013,CIN,2013_15_CIN_PIT,Jay Gruden,Mike Zimmer
-2013,CIN,2013_16_MIN_CIN,Jay Gruden,Mike Zimmer
-2013,CIN,2013_17_BAL_CIN,Jay Gruden,Mike Zimmer
-2013,CIN,2013_18_SD_CIN,Jay Gruden,Mike Zimmer
-2013,CLE,2013_01_MIA_CLE,Norv Turner,Ray Horton
-2013,CLE,2013_02_CLE_BAL,Norv Turner,Ray Horton
-2013,CLE,2013_03_CLE_MIN,Norv Turner,Ray Horton
-2013,CLE,2013_04_CIN_CLE,Norv Turner,Ray Horton
-2013,CLE,2013_05_BUF_CLE,Norv Turner,Ray Horton
-2013,CLE,2013_06_DET_CLE,Norv Turner,Ray Horton
-2013,CLE,2013_07_CLE_GB,Norv Turner,Ray Horton
-2013,CLE,2013_08_CLE_KC,Norv Turner,Ray Horton
-2013,CLE,2013_09_BAL_CLE,Norv Turner,Ray Horton
-2013,CLE,2013_11_CLE_CIN,Norv Turner,Ray Horton
-2013,CLE,2013_12_PIT_CLE,Norv Turner,Ray Horton
-2013,CLE,2013_13_JAX_CLE,Norv Turner,Ray Horton
-2013,CLE,2013_14_CLE_NE,Norv Turner,Ray Horton
-2013,CLE,2013_15_CHI_CLE,Norv Turner,Ray Horton
-2013,CLE,2013_16_CLE_NYJ,Norv Turner,Ray Horton
-2013,CLE,2013_17_CLE_PIT,Norv Turner,Ray Horton
-2013,DAL,2013_01_NYG_DAL,Bill Callahan,Monte Kiffin
-2013,DAL,2013_02_DAL_KC,Bill Callahan,Monte Kiffin
-2013,DAL,2013_03_STL_DAL,Bill Callahan,Monte Kiffin
-2013,DAL,2013_04_DAL_SD,Bill Callahan,Monte Kiffin
-2013,DAL,2013_05_DEN_DAL,Bill Callahan,Monte Kiffin
-2013,DAL,2013_06_WAS_DAL,Bill Callahan,Monte Kiffin
-2013,DAL,2013_07_DAL_PHI,Bill Callahan,Monte Kiffin
-2013,DAL,2013_08_DAL_DET,Bill Callahan,Monte Kiffin
-2013,DAL,2013_09_MIN_DAL,Bill Callahan,Monte Kiffin
-2013,DAL,2013_10_DAL_NO,Bill Callahan,Monte Kiffin
-2013,DAL,2013_12_DAL_NYG,Jason Garrett,Monte Kiffin
-2013,DAL,2013_13_OAK_DAL,Jason Garrett,Monte Kiffin
-2013,DAL,2013_14_DAL_CHI,Jason Garrett,Monte Kiffin
-2013,DAL,2013_15_GB_DAL,Jason Garrett,Monte Kiffin
-2013,DAL,2013_16_DAL_WAS,Jason Garrett,Monte Kiffin
-2013,DAL,2013_17_PHI_DAL,Jason Garrett,Monte Kiffin
-2013,DEN,2013_01_BAL_DEN,Adam Gase,Jack Del Rio
-2013,DEN,2013_02_DEN_NYG,Adam Gase,Monte Kiffin
-2013,DEN,2013_03_OAK_DEN,Adam Gase,Jack Del Rio
-2013,DEN,2013_04_PHI_DEN,Adam Gase,Monte Kiffin
-2013,DEN,2013_05_DEN_DAL,Adam Gase,Jack Del Rio
-2013,DEN,2013_06_JAX_DEN,Adam Gase,Monte Kiffin
-2013,DEN,2013_07_DEN_IND,Adam Gase,Jack Del Rio
-2013,DEN,2013_08_WAS_DEN,Adam Gase,Monte Kiffin
-2013,DEN,2013_10_DEN_SD,Adam Gase,Jack Del Rio
-2013,DEN,2013_11_KC_DEN,Adam Gase,Monte Kiffin
-2013,DEN,2013_12_DEN_NE,Adam Gase,Jack Del Rio
-2013,DEN,2013_13_DEN_KC,Adam Gase,Monte Kiffin
-2013,DEN,2013_14_TEN_DEN,Adam Gase,Jack Del Rio
-2013,DEN,2013_15_SD_DEN,Adam Gase,Monte Kiffin
-2013,DEN,2013_16_DEN_HOU,Adam Gase,Jack Del Rio
-2013,DEN,2013_17_DEN_OAK,Adam Gase,Monte Kiffin
-2013,DEN,2013_19_SD_DEN,Adam Gase,Jack Del Rio
-2013,DEN,2013_20_NE_DEN,Adam Gase,Monte Kiffin
-2013,DEN,2013_21_SEA_DEN,Adam Gase,Jack Del Rio
-2013,DET,2013_01_MIN_DET,Scott Linehan,Gunther Cunningham
-2013,DET,2013_02_DET_ARI,Scott Linehan,Gunther Cunningham
-2013,DET,2013_03_DET_WAS,Scott Linehan,Gunther Cunningham
-2013,DET,2013_04_CHI_DET,Scott Linehan,Gunther Cunningham
-2013,DET,2013_05_DET_GB,Scott Linehan,Gunther Cunningham
-2013,DET,2013_06_DET_CLE,Scott Linehan,Gunther Cunningham
-2013,DET,2013_07_CIN_DET,Scott Linehan,Gunther Cunningham
-2013,DET,2013_08_DAL_DET,Scott Linehan,Gunther Cunningham
-2013,DET,2013_10_DET_CHI,Scott Linehan,Gunther Cunningham
-2013,DET,2013_11_DET_PIT,Scott Linehan,Gunther Cunningham
-2013,DET,2013_12_TB_DET,Scott Linehan,Gunther Cunningham
-2013,DET,2013_13_GB_DET,Scott Linehan,Gunther Cunningham
-2013,DET,2013_14_DET_PHI,Scott Linehan,Gunther Cunningham
-2013,DET,2013_15_BAL_DET,Scott Linehan,Gunther Cunningham
-2013,DET,2013_16_NYG_DET,Scott Linehan,Gunther Cunningham
-2013,DET,2013_17_DET_MIN,Scott Linehan,Gunther Cunningham
-2013,GB,2013_01_GB_SF,Mike McCarthy,Dom Capers
-2013,GB,2013_02_WAS_GB,Mike McCarthy,Dom Capers
-2013,GB,2013_03_GB_CIN,Mike McCarthy,Dom Capers
-2013,GB,2013_05_DET_GB,Mike McCarthy,Dom Capers
-2013,GB,2013_06_GB_BAL,Mike McCarthy,Dom Capers
-2013,GB,2013_07_CLE_GB,Mike McCarthy,Dom Capers
-2013,GB,2013_08_GB_MIN,Mike McCarthy,Dom Capers
-2013,GB,2013_09_CHI_GB,Mike McCarthy,Dom Capers
-2013,GB,2013_10_PHI_GB,Mike McCarthy,Dom Capers
-2013,GB,2013_11_GB_NYG,Mike McCarthy,Dom Capers
-2013,GB,2013_12_MIN_GB,Mike McCarthy,Dom Capers
-2013,GB,2013_13_GB_DET,Mike McCarthy,Dom Capers
-2013,GB,2013_14_ATL_GB,Mike McCarthy,Dom Capers
-2013,GB,2013_15_GB_DAL,Mike McCarthy,Dom Capers
-2013,GB,2013_16_PIT_GB,Mike McCarthy,Dom Capers
-2013,GB,2013_17_GB_CHI,Mike McCarthy,Dom Capers
-2013,GB,2013_18_SF_GB,Mike McCarthy,Dom Capers
-2013,HOU,2013_01_HOU_SD,Gary Kubiak,Wade Phillips
-2013,HOU,2013_02_TEN_HOU,Gary Kubiak,Wade Phillips
-2013,HOU,2013_03_HOU_BAL,Gary Kubiak,Wade Phillips
-2013,HOU,2013_04_SEA_HOU,Gary Kubiak,Wade Phillips
-2013,HOU,2013_05_HOU_SF,Gary Kubiak,Wade Phillips
-2013,HOU,2013_06_STL_HOU,Gary Kubiak,Wade Phillips
-2013,HOU,2013_07_HOU_KC,Gary Kubiak,Wade Phillips
-2013,HOU,2013_09_IND_HOU,Gary Kubiak,Wade Phillips
-2013,HOU,2013_10_HOU_ARI,Rick Dennison,Wade Phillips
-2013,HOU,2013_11_OAK_HOU,Gary Kubiak,Wade Phillips
-2013,HOU,2013_12_JAX_HOU,Rick Dennison,Wade Phillips
-2013,HOU,2013_13_NE_HOU,Rick Dennison,Wade Phillips
-2013,HOU,2013_14_HOU_JAX,Rick Dennison,Wade Phillips
-2013,HOU,2013_15_HOU_IND,Rick Dennison,Wade Phillips
-2013,HOU,2013_16_DEN_HOU,Rick Dennison,Wade Phillips
-2013,HOU,2013_17_HOU_TEN,Rick Dennison,Wade Phillips
-2013,IND,2013_01_OAK_IND,Pep Hamilton,Greg Manusky
-2013,IND,2013_02_MIA_IND,Pep Hamilton,Greg Manusky
-2013,IND,2013_03_IND_SF,Pep Hamilton,Greg Manusky
-2013,IND,2013_04_IND_JAX,Pep Hamilton,Greg Manusky
-2013,IND,2013_05_SEA_IND,Pep Hamilton,Greg Manusky
-2013,IND,2013_06_IND_SD,Pep Hamilton,Greg Manusky
-2013,IND,2013_07_DEN_IND,Pep Hamilton,Greg Manusky
-2013,IND,2013_09_IND_HOU,Pep Hamilton,Greg Manusky
-2013,IND,2013_10_STL_IND,Pep Hamilton,Greg Manusky
-2013,IND,2013_11_IND_TEN,Pep Hamilton,Greg Manusky
-2013,IND,2013_12_IND_ARI,Pep Hamilton,Greg Manusky
-2013,IND,2013_13_TEN_IND,Pep Hamilton,Greg Manusky
-2013,IND,2013_14_IND_CIN,Pep Hamilton,Greg Manusky
-2013,IND,2013_15_HOU_IND,Pep Hamilton,Greg Manusky
-2013,IND,2013_16_IND_KC,Pep Hamilton,Greg Manusky
-2013,IND,2013_17_JAX_IND,Pep Hamilton,Greg Manusky
-2013,IND,2013_18_KC_IND,Pep Hamilton,Greg Manusky
-2013,IND,2013_19_IND_NE,Pep Hamilton,Greg Manusky
-2013,JAX,2013_01_KC_JAX,Jedd Fisch,Bob Babich
-2013,JAX,2013_02_JAX_OAK,Jedd Fisch,Bob Babich
-2013,JAX,2013_03_JAX_SEA,Jedd Fisch,Bob Babich
-2013,JAX,2013_04_IND_JAX,Jedd Fisch,Bob Babich
-2013,JAX,2013_05_JAX_STL,Jedd Fisch,Bob Babich
-2013,JAX,2013_06_JAX_DEN,Jedd Fisch,Bob Babich
-2013,JAX,2013_07_SD_JAX,Jedd Fisch,Bob Babich
-2013,JAX,2013_08_SF_JAX,Jedd Fisch,Bob Babich
-2013,JAX,2013_10_JAX_TEN,Jedd Fisch,Bob Babich
-2013,JAX,2013_11_ARI_JAX,Jedd Fisch,Bob Babich
-2013,JAX,2013_12_JAX_HOU,Jedd Fisch,Bob Babich
-2013,JAX,2013_13_JAX_CLE,Jedd Fisch,Bob Babich
-2013,JAX,2013_14_HOU_JAX,Jedd Fisch,Bob Babich
-2013,JAX,2013_15_BUF_JAX,Jedd Fisch,Bob Babich
-2013,JAX,2013_16_TEN_JAX,Jedd Fisch,Bob Babich
-2013,JAX,2013_17_JAX_IND,Jedd Fisch,Bob Babich
-2013,KC,2013_01_KC_JAX,Andy Reid,Bob Sutton
-2013,KC,2013_02_DAL_KC,Andy Reid,Bob Sutton
-2013,KC,2013_03_KC_PHI,Andy Reid,Bob Sutton
-2013,KC,2013_04_NYG_KC,Andy Reid,Bob Sutton
-2013,KC,2013_05_KC_TEN,Andy Reid,Bob Sutton
-2013,KC,2013_06_OAK_KC,Andy Reid,Bob Sutton
-2013,KC,2013_07_HOU_KC,Andy Reid,Bob Sutton
-2013,KC,2013_08_CLE_KC,Andy Reid,Bob Sutton
-2013,KC,2013_09_KC_BUF,Andy Reid,Bob Sutton
-2013,KC,2013_11_KC_DEN,Andy Reid,Bob Sutton
-2013,KC,2013_12_SD_KC,Andy Reid,Bob Sutton
-2013,KC,2013_13_DEN_KC,Andy Reid,Bob Sutton
-2013,KC,2013_14_KC_WAS,Andy Reid,Bob Sutton
-2013,KC,2013_15_KC_OAK,Andy Reid,Bob Sutton
-2013,KC,2013_16_IND_KC,Andy Reid,Bob Sutton
-2013,KC,2013_17_KC_SD,Andy Reid,Bob Sutton
-2013,KC,2013_18_KC_IND,Andy Reid,Bob Sutton
-2013,LA,2013_01_ARI_STL,Brian Schottenheimer,Tim Walton
-2013,LA,2013_02_STL_ATL,Brian Schottenheimer,Tim Walton
-2013,LA,2013_03_STL_DAL,Brian Schottenheimer,Tim Walton
-2013,LA,2013_04_SF_STL,Brian Schottenheimer,Tim Walton
-2013,LA,2013_05_JAX_STL,Brian Schottenheimer,Tim Walton
-2013,LA,2013_06_STL_HOU,Brian Schottenheimer,Tim Walton
-2013,LA,2013_07_STL_CAR,Brian Schottenheimer,Tim Walton
-2013,LA,2013_08_SEA_STL,Brian Schottenheimer,Tim Walton
-2013,LA,2013_09_TEN_STL,Brian Schottenheimer,Tim Walton
-2013,LA,2013_10_STL_IND,Brian Schottenheimer,Tim Walton
-2013,LA,2013_12_CHI_STL,Brian Schottenheimer,Tim Walton
-2013,LA,2013_13_STL_SF,Brian Schottenheimer,Tim Walton
-2013,LA,2013_14_STL_ARI,Brian Schottenheimer,Tim Walton
-2013,LA,2013_15_NO_STL,Brian Schottenheimer,Tim Walton
-2013,LA,2013_16_TB_STL,Brian Schottenheimer,Tim Walton
-2013,LA,2013_17_STL_SEA,Brian Schottenheimer,Tim Walton
-2013,LAC,2013_01_HOU_SD,Ken Whisenhunt,John Pagano
-2013,LAC,2013_02_SD_PHI,Ken Whisenhunt,John Pagano
-2013,LAC,2013_03_SD_TEN,Ken Whisenhunt,John Pagano
-2013,LAC,2013_04_DAL_SD,Ken Whisenhunt,John Pagano
-2013,LAC,2013_05_SD_OAK,Ken Whisenhunt,John Pagano
-2013,LAC,2013_06_IND_SD,Ken Whisenhunt,John Pagano
-2013,LAC,2013_07_SD_JAX,Ken Whisenhunt,John Pagano
-2013,LAC,2013_09_SD_WAS,Ken Whisenhunt,John Pagano
-2013,LAC,2013_10_DEN_SD,Ken Whisenhunt,John Pagano
-2013,LAC,2013_11_SD_MIA,Ken Whisenhunt,John Pagano
-2013,LAC,2013_12_SD_KC,Ken Whisenhunt,John Pagano
-2013,LAC,2013_13_CIN_SD,Ken Whisenhunt,John Pagano
-2013,LAC,2013_14_NYG_SD,Ken Whisenhunt,John Pagano
-2013,LAC,2013_15_SD_DEN,Ken Whisenhunt,John Pagano
-2013,LAC,2013_16_OAK_SD,Ken Whisenhunt,John Pagano
-2013,LAC,2013_17_KC_SD,Ken Whisenhunt,John Pagano
-2013,LAC,2013_18_SD_CIN,Ken Whisenhunt,John Pagano
-2013,LAC,2013_19_SD_DEN,Ken Whisenhunt,John Pagano
-2013,LV,2013_01_OAK_IND,Greg Olson,Jason Tarver
-2013,LV,2013_02_JAX_OAK,Greg Olson,Jason Tarver
-2013,LV,2013_03_OAK_DEN,Greg Olson,Jason Tarver
-2013,LV,2013_04_WAS_OAK,Greg Olson,Jason Tarver
-2013,LV,2013_05_SD_OAK,Greg Olson,Jason Tarver
-2013,LV,2013_06_OAK_KC,Greg Olson,Jason Tarver
-2013,LV,2013_08_PIT_OAK,Greg Olson,Jason Tarver
-2013,LV,2013_09_PHI_OAK,Greg Olson,Jason Tarver
-2013,LV,2013_10_OAK_NYG,Greg Olson,Jason Tarver
-2013,LV,2013_11_OAK_HOU,Greg Olson,Jason Tarver
-2013,LV,2013_12_TEN_OAK,Greg Olson,Jason Tarver
-2013,LV,2013_13_OAK_DAL,Greg Olson,Jason Tarver
-2013,LV,2013_14_OAK_NYJ,Greg Olson,Jason Tarver
-2013,LV,2013_15_KC_OAK,Greg Olson,Jason Tarver
-2013,LV,2013_16_OAK_SD,Greg Olson,Jason Tarver
-2013,LV,2013_17_DEN_OAK,Greg Olson,Jason Tarver
-2013,MIA,2013_01_MIA_CLE,Mike Sherman,Kevin Coyle
-2013,MIA,2013_02_MIA_IND,Mike Sherman,Kevin Coyle
-2013,MIA,2013_03_ATL_MIA,Mike Sherman,Kevin Coyle
-2013,MIA,2013_04_MIA_NO,Mike Sherman,Kevin Coyle
-2013,MIA,2013_05_BAL_MIA,Mike Sherman,Kevin Coyle
-2013,MIA,2013_07_BUF_MIA,Mike Sherman,Kevin Coyle
-2013,MIA,2013_08_MIA_NE,Mike Sherman,Kevin Coyle
-2013,MIA,2013_09_CIN_MIA,Mike Sherman,Kevin Coyle
-2013,MIA,2013_10_MIA_TB,Mike Sherman,Kevin Coyle
-2013,MIA,2013_11_SD_MIA,Mike Sherman,Kevin Coyle
-2013,MIA,2013_12_CAR_MIA,Mike Sherman,Kevin Coyle
-2013,MIA,2013_13_MIA_NYJ,Mike Sherman,Kevin Coyle
-2013,MIA,2013_14_MIA_PIT,Mike Sherman,Kevin Coyle
-2013,MIA,2013_15_NE_MIA,Mike Sherman,Kevin Coyle
-2013,MIA,2013_16_MIA_BUF,Mike Sherman,Kevin Coyle
-2013,MIA,2013_17_NYJ_MIA,Mike Sherman,Kevin Coyle
-2013,MIN,2013_01_MIN_DET,Bill Musgrave,Alan Williams
-2013,MIN,2013_02_MIN_CHI,Bill Musgrave,Alan Williams
-2013,MIN,2013_03_CLE_MIN,Bill Musgrave,Alan Williams
-2013,MIN,2013_04_PIT_MIN,Bill Musgrave,Alan Williams
-2013,MIN,2013_06_CAR_MIN,Bill Musgrave,Alan Williams
-2013,MIN,2013_07_MIN_NYG,Bill Musgrave,Alan Williams
-2013,MIN,2013_08_GB_MIN,Bill Musgrave,Alan Williams
-2013,MIN,2013_09_MIN_DAL,Bill Musgrave,Alan Williams
-2013,MIN,2013_10_WAS_MIN,Bill Musgrave,Alan Williams
-2013,MIN,2013_11_MIN_SEA,Bill Musgrave,Alan Williams
-2013,MIN,2013_12_MIN_GB,Bill Musgrave,Alan Williams
-2013,MIN,2013_13_CHI_MIN,Bill Musgrave,Alan Williams
-2013,MIN,2013_14_MIN_BAL,Bill Musgrave,Alan Williams
-2013,MIN,2013_15_PHI_MIN,Bill Musgrave,Alan Williams
-2013,MIN,2013_16_MIN_CIN,Bill Musgrave,Alan Williams
-2013,MIN,2013_17_DET_MIN,Bill Musgrave,Alan Williams
-2013,NE,2013_01_NE_BUF,Josh McDaniels,Matt Patricia
-2013,NE,2013_02_NYJ_NE,Josh McDaniels,Matt Patricia
-2013,NE,2013_03_TB_NE,Josh McDaniels,Matt Patricia
-2013,NE,2013_04_NE_ATL,Josh McDaniels,Matt Patricia
-2013,NE,2013_05_NE_CIN,Josh McDaniels,Matt Patricia
-2013,NE,2013_06_NO_NE,Josh McDaniels,Matt Patricia
-2013,NE,2013_07_NE_NYJ,Josh McDaniels,Matt Patricia
-2013,NE,2013_08_MIA_NE,Josh McDaniels,Matt Patricia
-2013,NE,2013_09_PIT_NE,Josh McDaniels,Matt Patricia
-2013,NE,2013_11_NE_CAR,Josh McDaniels,Matt Patricia
-2013,NE,2013_12_DEN_NE,Josh McDaniels,Matt Patricia
-2013,NE,2013_13_NE_HOU,Josh McDaniels,Matt Patricia
-2013,NE,2013_14_CLE_NE,Josh McDaniels,Matt Patricia
-2013,NE,2013_15_NE_MIA,Josh McDaniels,Matt Patricia
-2013,NE,2013_16_NE_BAL,Josh McDaniels,Matt Patricia
-2013,NE,2013_17_BUF_NE,Josh McDaniels,Matt Patricia
-2013,NE,2013_19_IND_NE,Josh McDaniels,Matt Patricia
-2013,NE,2013_20_NE_DEN,Josh McDaniels,Matt Patricia
-2013,NO,2013_01_ATL_NO,Sean Payton,Rob Ryan
-2013,NO,2013_02_NO_TB,Sean Payton,Rob Ryan
-2013,NO,2013_03_ARI_NO,Sean Payton,Rob Ryan
-2013,NO,2013_04_MIA_NO,Sean Payton,Rob Ryan
-2013,NO,2013_05_NO_CHI,Sean Payton,Rob Ryan
-2013,NO,2013_06_NO_NE,Sean Payton,Rob Ryan
-2013,NO,2013_08_BUF_NO,Sean Payton,Rob Ryan
-2013,NO,2013_09_NO_NYJ,Sean Payton,Rob Ryan
-2013,NO,2013_10_DAL_NO,Sean Payton,Rob Ryan
-2013,NO,2013_11_SF_NO,Sean Payton,Rob Ryan
-2013,NO,2013_12_NO_ATL,Sean Payton,Rob Ryan
-2013,NO,2013_13_NO_SEA,Sean Payton,Rob Ryan
-2013,NO,2013_14_CAR_NO,Sean Payton,Rob Ryan
-2013,NO,2013_15_NO_STL,Sean Payton,Rob Ryan
-2013,NO,2013_16_NO_CAR,Sean Payton,Rob Ryan
-2013,NO,2013_17_TB_NO,Sean Payton,Rob Ryan
-2013,NO,2013_18_NO_PHI,Sean Payton,Rob Ryan
-2013,NO,2013_19_NO_SEA,Sean Payton,Rob Ryan
-2013,NYG,2013_01_NYG_DAL,Kevin Gilbride,Perry Fewell
-2013,NYG,2013_02_DEN_NYG,Kevin Gilbride,Perry Fewell
-2013,NYG,2013_03_NYG_CAR,Kevin Gilbride,Perry Fewell
-2013,NYG,2013_04_NYG_KC,Kevin Gilbride,Perry Fewell
-2013,NYG,2013_05_PHI_NYG,Kevin Gilbride,Perry Fewell
-2013,NYG,2013_06_NYG_CHI,Kevin Gilbride,Perry Fewell
-2013,NYG,2013_07_MIN_NYG,Kevin Gilbride,Perry Fewell
-2013,NYG,2013_08_NYG_PHI,Kevin Gilbride,Perry Fewell
-2013,NYG,2013_10_OAK_NYG,Kevin Gilbride,Perry Fewell
-2013,NYG,2013_11_GB_NYG,Kevin Gilbride,Perry Fewell
-2013,NYG,2013_12_DAL_NYG,Kevin Gilbride,Perry Fewell
-2013,NYG,2013_13_NYG_WAS,Kevin Gilbride,Perry Fewell
-2013,NYG,2013_14_NYG_SD,Kevin Gilbride,Perry Fewell
-2013,NYG,2013_15_SEA_NYG,Kevin Gilbride,Perry Fewell
-2013,NYG,2013_16_NYG_DET,Kevin Gilbride,Perry Fewell
-2013,NYG,2013_17_WAS_NYG,Kevin Gilbride,Perry Fewell
-2013,NYJ,2013_01_TB_NYJ,Marty Mornhinweg,Dennis Thurman
-2013,NYJ,2013_02_NYJ_NE,Marty Mornhinweg,Dennis Thurman
-2013,NYJ,2013_03_BUF_NYJ,Marty Mornhinweg,Dennis Thurman
-2013,NYJ,2013_04_NYJ_TEN,Marty Mornhinweg,Dennis Thurman
-2013,NYJ,2013_05_NYJ_ATL,Marty Mornhinweg,Dennis Thurman
-2013,NYJ,2013_06_PIT_NYJ,Marty Mornhinweg,Dennis Thurman
-2013,NYJ,2013_07_NE_NYJ,Marty Mornhinweg,Dennis Thurman
-2013,NYJ,2013_08_NYJ_CIN,Marty Mornhinweg,Dennis Thurman
-2013,NYJ,2013_09_NO_NYJ,Marty Mornhinweg,Dennis Thurman
-2013,NYJ,2013_11_NYJ_BUF,Marty Mornhinweg,Dennis Thurman
-2013,NYJ,2013_12_NYJ_BAL,Marty Mornhinweg,Dennis Thurman
-2013,NYJ,2013_13_MIA_NYJ,Marty Mornhinweg,Dennis Thurman
-2013,NYJ,2013_14_OAK_NYJ,Marty Mornhinweg,Dennis Thurman
-2013,NYJ,2013_15_NYJ_CAR,Marty Mornhinweg,Dennis Thurman
-2013,NYJ,2013_16_CLE_NYJ,Marty Mornhinweg,Dennis Thurman
-2013,NYJ,2013_17_NYJ_MIA,Marty Mornhinweg,Dennis Thurman
-2013,PHI,2013_01_PHI_WAS,Chip Kelly,Billy Davis
-2013,PHI,2013_02_SD_PHI,Chip Kelly,Billy Davis
-2013,PHI,2013_03_KC_PHI,Chip Kelly,Billy Davis
-2013,PHI,2013_04_PHI_DEN,Chip Kelly,Billy Davis
-2013,PHI,2013_05_PHI_NYG,Chip Kelly,Billy Davis
-2013,PHI,2013_06_PHI_TB,Chip Kelly,Billy Davis
-2013,PHI,2013_07_DAL_PHI,Chip Kelly,Billy Davis
-2013,PHI,2013_08_NYG_PHI,Chip Kelly,Billy Davis
-2013,PHI,2013_09_PHI_OAK,Chip Kelly,Billy Davis
-2013,PHI,2013_10_PHI_GB,Chip Kelly,Billy Davis
-2013,PHI,2013_11_WAS_PHI,Chip Kelly,Billy Davis
-2013,PHI,2013_13_ARI_PHI,Chip Kelly,Billy Davis
-2013,PHI,2013_14_DET_PHI,Chip Kelly,Billy Davis
-2013,PHI,2013_15_PHI_MIN,Chip Kelly,Billy Davis
-2013,PHI,2013_16_CHI_PHI,Chip Kelly,Billy Davis
-2013,PHI,2013_17_PHI_DAL,Chip Kelly,Billy Davis
-2013,PHI,2013_18_NO_PHI,Chip Kelly,Billy Davis
-2013,PIT,2013_01_TEN_PIT,Todd Haley,Mike Tomlin
-2013,PIT,2013_02_PIT_CIN,Todd Haley,Mike Tomlin
-2013,PIT,2013_03_CHI_PIT,Todd Haley,Mike Tomlin
-2013,PIT,2013_04_PIT_MIN,Todd Haley,Mike Tomlin
-2013,PIT,2013_06_PIT_NYJ,Todd Haley,Mike Tomlin
-2013,PIT,2013_07_BAL_PIT,Todd Haley,Mike Tomlin
-2013,PIT,2013_08_PIT_OAK,Todd Haley,Mike Tomlin
-2013,PIT,2013_09_PIT_NE,Todd Haley,Mike Tomlin
-2013,PIT,2013_10_BUF_PIT,Todd Haley,Mike Tomlin
-2013,PIT,2013_11_DET_PIT,Todd Haley,Mike Tomlin
-2013,PIT,2013_12_PIT_CLE,Todd Haley,Mike Tomlin
-2013,PIT,2013_13_PIT_BAL,Todd Haley,Mike Tomlin
-2013,PIT,2013_14_MIA_PIT,Todd Haley,Mike Tomlin
-2013,PIT,2013_15_CIN_PIT,Todd Haley,Mike Tomlin
-2013,PIT,2013_16_PIT_GB,Todd Haley,Mike Tomlin
-2013,PIT,2013_17_CLE_PIT,Todd Haley,Mike Tomlin
-2013,SEA,2013_01_SEA_CAR,Darrell Bevell,Dan Quinn
-2013,SEA,2013_02_SF_SEA,Darrell Bevell,Dan Quinn
-2013,SEA,2013_03_JAX_SEA,Darrell Bevell,Dan Quinn
-2013,SEA,2013_04_SEA_HOU,Darrell Bevell,Dan Quinn
-2013,SEA,2013_05_SEA_IND,Darrell Bevell,Dan Quinn
-2013,SEA,2013_06_TEN_SEA,Darrell Bevell,Dan Quinn
-2013,SEA,2013_07_SEA_ARI,Darrell Bevell,Dan Quinn
-2013,SEA,2013_08_SEA_STL,Darrell Bevell,Dan Quinn
-2013,SEA,2013_09_TB_SEA,Darrell Bevell,Dan Quinn
-2013,SEA,2013_10_SEA_ATL,Darrell Bevell,Dan Quinn
-2013,SEA,2013_11_MIN_SEA,Darrell Bevell,Dan Quinn
-2013,SEA,2013_13_NO_SEA,Darrell Bevell,Dan Quinn
-2013,SEA,2013_14_SEA_SF,Darrell Bevell,Dan Quinn
-2013,SEA,2013_15_SEA_NYG,Darrell Bevell,Dan Quinn
-2013,SEA,2013_16_ARI_SEA,Darrell Bevell,Dan Quinn
-2013,SEA,2013_17_STL_SEA,Darrell Bevell,Dan Quinn
-2013,SEA,2013_19_NO_SEA,Darrell Bevell,Dan Quinn
-2013,SEA,2013_20_SF_SEA,Darrell Bevell,Dan Quinn
-2013,SEA,2013_21_SEA_DEN,Darrell Bevell,Dan Quinn
-2013,SF,2013_01_GB_SF,Greg Roman,Vic Fangio
-2013,SF,2013_02_SF_SEA,Greg Roman,Vic Fangio
-2013,SF,2013_03_IND_SF,Greg Roman,Vic Fangio
-2013,SF,2013_04_SF_STL,Greg Roman,Vic Fangio
-2013,SF,2013_05_HOU_SF,Greg Roman,Vic Fangio
-2013,SF,2013_06_ARI_SF,Greg Roman,Vic Fangio
-2013,SF,2013_07_SF_TEN,Greg Roman,Vic Fangio
-2013,SF,2013_08_SF_JAX,Greg Roman,Vic Fangio
-2013,SF,2013_10_CAR_SF,Greg Roman,Vic Fangio
-2013,SF,2013_11_SF_NO,Greg Roman,Vic Fangio
-2013,SF,2013_12_SF_WAS,Greg Roman,Vic Fangio
-2013,SF,2013_13_STL_SF,Greg Roman,Vic Fangio
-2013,SF,2013_14_SEA_SF,Greg Roman,Vic Fangio
-2013,SF,2013_15_SF_TB,Greg Roman,Vic Fangio
-2013,SF,2013_16_ATL_SF,Greg Roman,Vic Fangio
-2013,SF,2013_17_SF_ARI,Greg Roman,Vic Fangio
-2013,SF,2013_18_SF_GB,Greg Roman,Vic Fangio
-2013,SF,2013_19_SF_CAR,Greg Roman,Vic Fangio
-2013,SF,2013_20_SF_SEA,Greg Roman,Vic Fangio
-2013,TB,2013_01_TB_NYJ,Mike Sullivan,Bill Sheridan
-2013,TB,2013_02_NO_TB,Mike Sullivan,Bill Sheridan
-2013,TB,2013_03_TB_NE,Mike Sullivan,Bill Sheridan
-2013,TB,2013_04_ARI_TB,Mike Sullivan,Bill Sheridan
-2013,TB,2013_06_PHI_TB,Mike Sullivan,Bill Sheridan
-2013,TB,2013_07_TB_ATL,Mike Sullivan,Bill Sheridan
-2013,TB,2013_08_CAR_TB,Mike Sullivan,Bill Sheridan
-2013,TB,2013_09_TB_SEA,Mike Sullivan,Bill Sheridan
-2013,TB,2013_10_MIA_TB,Mike Sullivan,Bill Sheridan
-2013,TB,2013_11_ATL_TB,Mike Sullivan,Bill Sheridan
-2013,TB,2013_12_TB_DET,Mike Sullivan,Bill Sheridan
-2013,TB,2013_13_TB_CAR,Mike Sullivan,Bill Sheridan
-2013,TB,2013_14_BUF_TB,Mike Sullivan,Bill Sheridan
-2013,TB,2013_15_SF_TB,Mike Sullivan,Bill Sheridan
-2013,TB,2013_16_TB_STL,Mike Sullivan,Bill Sheridan
-2013,TB,2013_17_TB_NO,Mike Sullivan,Bill Sheridan
-2013,TEN,2013_01_TEN_PIT,Dowell Loggains,Jerry Gray
-2013,TEN,2013_02_TEN_HOU,Dowell Loggains,Jerry Gray
-2013,TEN,2013_03_SD_TEN,Dowell Loggains,Jerry Gray
-2013,TEN,2013_04_NYJ_TEN,Dowell Loggains,Jerry Gray
-2013,TEN,2013_05_KC_TEN,Dowell Loggains,Jerry Gray
-2013,TEN,2013_06_TEN_SEA,Dowell Loggains,Jerry Gray
-2013,TEN,2013_07_SF_TEN,Dowell Loggains,Jerry Gray
-2013,TEN,2013_09_TEN_STL,Dowell Loggains,Jerry Gray
-2013,TEN,2013_10_JAX_TEN,Dowell Loggains,Jerry Gray
-2013,TEN,2013_11_IND_TEN,Dowell Loggains,Jerry Gray
-2013,TEN,2013_12_TEN_OAK,Dowell Loggains,Jerry Gray
-2013,TEN,2013_13_TEN_IND,Dowell Loggains,Jerry Gray
-2013,TEN,2013_14_TEN_DEN,Dowell Loggains,Jerry Gray
-2013,TEN,2013_15_ARI_TEN,Dowell Loggains,Jerry Gray
-2013,TEN,2013_16_TEN_JAX,Dowell Loggains,Jerry Gray
-2013,TEN,2013_17_HOU_TEN,Dowell Loggains,Jerry Gray
-2013,WAS,2013_01_PHI_WAS,Kyle Shanahan,Jim Haslett
-2013,WAS,2013_02_WAS_GB,Kyle Shanahan,Jim Haslett
-2013,WAS,2013_03_DET_WAS,Kyle Shanahan,Jim Haslett
-2013,WAS,2013_04_WAS_OAK,Kyle Shanahan,Jim Haslett
-2013,WAS,2013_06_WAS_DAL,Kyle Shanahan,Jim Haslett
-2013,WAS,2013_07_CHI_WAS,Kyle Shanahan,Jim Haslett
-2013,WAS,2013_08_WAS_DEN,Kyle Shanahan,Jim Haslett
-2013,WAS,2013_09_SD_WAS,Kyle Shanahan,Jim Haslett
-2013,WAS,2013_10_WAS_MIN,Kyle Shanahan,Jim Haslett
-2013,WAS,2013_11_WAS_PHI,Kyle Shanahan,Jim Haslett
-2013,WAS,2013_12_SF_WAS,Kyle Shanahan,Jim Haslett
-2013,WAS,2013_13_NYG_WAS,Kyle Shanahan,Jim Haslett
-2013,WAS,2013_14_KC_WAS,Kyle Shanahan,Jim Haslett
-2013,WAS,2013_15_WAS_ATL,Kyle Shanahan,Jim Haslett
-2013,WAS,2013_16_DAL_WAS,Kyle Shanahan,Jim Haslett
-2013,WAS,2013_17_WAS_NYG,Kyle Shanahan,Jim Haslett
 2014,ARI,2014_01_SD_ARI,Bruce Arians,Todd Bowles
 2014,ARI,2014_02_ARI_NYG,Bruce Arians,Todd Bowles
 2014,ARI,2014_03_SF_ARI,Bruce Arians,Todd Bowles
@@ -550,523 +32,6 @@ season,team,game_id,off_play_caller,def_play_caller
 2014,ARI,2014_16_SEA_ARI,Bruce Arians,Todd Bowles
 2014,ARI,2014_17_ARI_SF,Bruce Arians,Todd Bowles
 2014,ARI,2014_18_ARI_CAR,Bruce Arians,Todd Bowles
-2014,ATL,2014_01_NO_ATL,Dirk Koetter,Mike Nolan
-2014,ATL,2014_02_ATL_CIN,Dirk Koetter,Mike Nolan
-2014,ATL,2014_03_TB_ATL,Dirk Koetter,Mike Nolan
-2014,ATL,2014_04_ATL_MIN,Dirk Koetter,Mike Nolan
-2014,ATL,2014_05_ATL_NYG,Dirk Koetter,Mike Nolan
-2014,ATL,2014_06_CHI_ATL,Dirk Koetter,Mike Nolan
-2014,ATL,2014_07_ATL_BAL,Dirk Koetter,Mike Nolan
-2014,ATL,2014_08_DET_ATL,Dirk Koetter,Mike Nolan
-2014,ATL,2014_10_ATL_TB,Dirk Koetter,Mike Nolan
-2014,ATL,2014_11_ATL_CAR,Dirk Koetter,Mike Nolan
-2014,ATL,2014_12_CLE_ATL,Dirk Koetter,Mike Nolan
-2014,ATL,2014_13_ARI_ATL,Dirk Koetter,Mike Nolan
-2014,ATL,2014_14_ATL_GB,Dirk Koetter,Mike Nolan
-2014,ATL,2014_15_PIT_ATL,Dirk Koetter,Mike Nolan
-2014,ATL,2014_16_ATL_NO,Dirk Koetter,Mike Nolan
-2014,ATL,2014_17_CAR_ATL,Dirk Koetter,Mike Nolan
-2014,BAL,2014_01_CIN_BAL,Gary Kubiak,Dean Pees
-2014,BAL,2014_02_PIT_BAL,Gary Kubiak,Dean Pees
-2014,BAL,2014_03_BAL_CLE,Gary Kubiak,Dean Pees
-2014,BAL,2014_04_CAR_BAL,Gary Kubiak,Dean Pees
-2014,BAL,2014_05_BAL_IND,Gary Kubiak,Dean Pees
-2014,BAL,2014_06_BAL_TB,Gary Kubiak,Dean Pees
-2014,BAL,2014_07_ATL_BAL,Gary Kubiak,Dean Pees
-2014,BAL,2014_08_BAL_CIN,Gary Kubiak,Dean Pees
-2014,BAL,2014_09_BAL_PIT,Gary Kubiak,Dean Pees
-2014,BAL,2014_10_TEN_BAL,Gary Kubiak,Dean Pees
-2014,BAL,2014_12_BAL_NO,Gary Kubiak,Dean Pees
-2014,BAL,2014_13_SD_BAL,Gary Kubiak,Dean Pees
-2014,BAL,2014_14_BAL_MIA,Gary Kubiak,Dean Pees
-2014,BAL,2014_15_JAX_BAL,Gary Kubiak,Dean Pees
-2014,BAL,2014_16_BAL_HOU,Gary Kubiak,Dean Pees
-2014,BAL,2014_17_CLE_BAL,Gary Kubiak,Dean Pees
-2014,BAL,2014_18_BAL_PIT,Gary Kubiak,Dean Pees
-2014,BAL,2014_19_BAL_NE,Gary Kubiak,Dean Pees
-2014,BUF,2014_01_BUF_CHI,Nathaniel Hackett,Jim Schwartz
-2014,BUF,2014_02_MIA_BUF,Nathaniel Hackett,Jim Schwartz
-2014,BUF,2014_03_SD_BUF,Nathaniel Hackett,Jim Schwartz
-2014,BUF,2014_04_BUF_HOU,Nathaniel Hackett,Jim Schwartz
-2014,BUF,2014_05_BUF_DET,Nathaniel Hackett,Jim Schwartz
-2014,BUF,2014_06_NE_BUF,Nathaniel Hackett,Jim Schwartz
-2014,BUF,2014_07_MIN_BUF,Nathaniel Hackett,Jim Schwartz
-2014,BUF,2014_08_BUF_NYJ,Nathaniel Hackett,Jim Schwartz
-2014,BUF,2014_10_KC_BUF,Nathaniel Hackett,Jim Schwartz
-2014,BUF,2014_11_BUF_MIA,Nathaniel Hackett,Jim Schwartz
-2014,BUF,2014_12_NYJ_BUF,Nathaniel Hackett,Jim Schwartz
-2014,BUF,2014_13_CLE_BUF,Nathaniel Hackett,Jim Schwartz
-2014,BUF,2014_14_BUF_DEN,Nathaniel Hackett,Jim Schwartz
-2014,BUF,2014_15_GB_BUF,Nathaniel Hackett,Jim Schwartz
-2014,BUF,2014_16_BUF_OAK,Nathaniel Hackett,Jim Schwartz
-2014,BUF,2014_17_BUF_NE,Nathaniel Hackett,Jim Schwartz
-2014,CAR,2014_01_CAR_TB,Mike Shula,Sean McDermott
-2014,CAR,2014_02_DET_CAR,Mike Shula,Sean McDermott
-2014,CAR,2014_03_PIT_CAR,Mike Shula,Sean McDermott
-2014,CAR,2014_04_CAR_BAL,Mike Shula,Sean McDermott
-2014,CAR,2014_05_CHI_CAR,Mike Shula,Sean McDermott
-2014,CAR,2014_06_CAR_CIN,Mike Shula,Sean McDermott
-2014,CAR,2014_07_CAR_GB,Mike Shula,Sean McDermott
-2014,CAR,2014_08_SEA_CAR,Mike Shula,Sean McDermott
-2014,CAR,2014_09_NO_CAR,Mike Shula,Sean McDermott
-2014,CAR,2014_10_CAR_PHI,Mike Shula,Sean McDermott
-2014,CAR,2014_11_ATL_CAR,Mike Shula,Sean McDermott
-2014,CAR,2014_13_CAR_MIN,Mike Shula,Sean McDermott
-2014,CAR,2014_14_CAR_NO,Mike Shula,Sean McDermott
-2014,CAR,2014_15_TB_CAR,Mike Shula,Sean McDermott
-2014,CAR,2014_16_CLE_CAR,Mike Shula,Sean McDermott
-2014,CAR,2014_17_CAR_ATL,Mike Shula,Sean McDermott
-2014,CAR,2014_18_ARI_CAR,Mike Shula,Sean McDermott
-2014,CAR,2014_19_CAR_SEA,Mike Shula,Sean McDermott
-2014,CHI,2014_01_BUF_CHI,Marc Trestman,Mel Tucker
-2014,CHI,2014_02_CHI_SF,Marc Trestman,Mel Tucker
-2014,CHI,2014_03_CHI_NYJ,Marc Trestman,Mel Tucker
-2014,CHI,2014_04_GB_CHI,Marc Trestman,Mel Tucker
-2014,CHI,2014_05_CHI_CAR,Marc Trestman,Mel Tucker
-2014,CHI,2014_06_CHI_ATL,Marc Trestman,Mel Tucker
-2014,CHI,2014_07_MIA_CHI,Marc Trestman,Mel Tucker
-2014,CHI,2014_08_CHI_NE,Marc Trestman,Mel Tucker
-2014,CHI,2014_10_CHI_GB,Marc Trestman,Mel Tucker
-2014,CHI,2014_11_MIN_CHI,Marc Trestman,Mel Tucker
-2014,CHI,2014_12_TB_CHI,Marc Trestman,Mel Tucker
-2014,CHI,2014_13_CHI_DET,Marc Trestman,Mel Tucker
-2014,CHI,2014_14_DAL_CHI,Marc Trestman,Mel Tucker
-2014,CHI,2014_15_NO_CHI,Marc Trestman,Mel Tucker
-2014,CHI,2014_16_DET_CHI,Marc Trestman,Mel Tucker
-2014,CHI,2014_17_CHI_MIN,Marc Trestman,Mel Tucker
-2014,CIN,2014_01_CIN_BAL,Hue Jackson,Paul Guenther
-2014,CIN,2014_02_ATL_CIN,Hue Jackson,Paul Guenther
-2014,CIN,2014_03_TEN_CIN,Hue Jackson,Paul Guenther
-2014,CIN,2014_05_CIN_NE,Hue Jackson,Paul Guenther
-2014,CIN,2014_06_CAR_CIN,Hue Jackson,Paul Guenther
-2014,CIN,2014_07_CIN_IND,Hue Jackson,Paul Guenther
-2014,CIN,2014_08_BAL_CIN,Hue Jackson,Paul Guenther
-2014,CIN,2014_09_JAX_CIN,Hue Jackson,Paul Guenther
-2014,CIN,2014_10_CLE_CIN,Hue Jackson,Paul Guenther
-2014,CIN,2014_11_CIN_NO,Hue Jackson,Paul Guenther
-2014,CIN,2014_12_CIN_HOU,Hue Jackson,Paul Guenther
-2014,CIN,2014_13_CIN_TB,Hue Jackson,Paul Guenther
-2014,CIN,2014_14_PIT_CIN,Hue Jackson,Paul Guenther
-2014,CIN,2014_15_CIN_CLE,Hue Jackson,Paul Guenther
-2014,CIN,2014_16_DEN_CIN,Hue Jackson,Paul Guenther
-2014,CIN,2014_17_CIN_PIT,Hue Jackson,Paul Guenther
-2014,CIN,2014_18_CIN_IND,Hue Jackson,Paul Guenther
-2014,CLE,2014_01_CLE_PIT,Kyle Shanahan,Jim O'Neil
-2014,CLE,2014_02_NO_CLE,Kyle Shanahan,Jim O'Neil
-2014,CLE,2014_03_BAL_CLE,Kyle Shanahan,Jim O'Neil
-2014,CLE,2014_05_CLE_TEN,Kyle Shanahan,Jim O'Neil
-2014,CLE,2014_06_PIT_CLE,Kyle Shanahan,Jim O'Neil
-2014,CLE,2014_07_CLE_JAX,Kyle Shanahan,Jim O'Neil
-2014,CLE,2014_08_OAK_CLE,Kyle Shanahan,Jim O'Neil
-2014,CLE,2014_09_TB_CLE,Kyle Shanahan,Jim O'Neil
-2014,CLE,2014_10_CLE_CIN,Kyle Shanahan,Jim O'Neil
-2014,CLE,2014_11_HOU_CLE,Kyle Shanahan,Jim O'Neil
-2014,CLE,2014_12_CLE_ATL,Kyle Shanahan,Jim O'Neil
-2014,CLE,2014_13_CLE_BUF,Kyle Shanahan,Jim O'Neil
-2014,CLE,2014_14_IND_CLE,Kyle Shanahan,Jim O'Neil
-2014,CLE,2014_15_CIN_CLE,Kyle Shanahan,Jim O'Neil
-2014,CLE,2014_16_CLE_CAR,Kyle Shanahan,Jim O'Neil
-2014,CLE,2014_17_CLE_BAL,Kyle Shanahan,Jim O'Neil
-2014,DAL,2014_01_SF_DAL,Scott Linehan,Rod Marinelli
-2014,DAL,2014_02_DAL_TEN,Scott Linehan,Rod Marinelli
-2014,DAL,2014_03_DAL_STL,Scott Linehan,Rod Marinelli
-2014,DAL,2014_04_NO_DAL,Scott Linehan,Rod Marinelli
-2014,DAL,2014_05_HOU_DAL,Scott Linehan,Rod Marinelli
-2014,DAL,2014_06_DAL_SEA,Scott Linehan,Rod Marinelli
-2014,DAL,2014_07_NYG_DAL,Scott Linehan,Rod Marinelli
-2014,DAL,2014_08_WAS_DAL,Scott Linehan,Rod Marinelli
-2014,DAL,2014_09_ARI_DAL,Scott Linehan,Rod Marinelli
-2014,DAL,2014_10_DAL_JAX,Scott Linehan,Rod Marinelli
-2014,DAL,2014_12_DAL_NYG,Scott Linehan,Rod Marinelli
-2014,DAL,2014_13_PHI_DAL,Scott Linehan,Rod Marinelli
-2014,DAL,2014_14_DAL_CHI,Scott Linehan,Rod Marinelli
-2014,DAL,2014_15_DAL_PHI,Scott Linehan,Rod Marinelli
-2014,DAL,2014_16_IND_DAL,Scott Linehan,Rod Marinelli
-2014,DAL,2014_17_DAL_WAS,Scott Linehan,Rod Marinelli
-2014,DAL,2014_18_DET_DAL,Scott Linehan,Rod Marinelli
-2014,DAL,2014_19_DAL_GB,Scott Linehan,Rod Marinelli
-2014,DEN,2014_01_IND_DEN,Adam Gase,Jack Del Rio
-2014,DEN,2014_02_KC_DEN,Adam Gase,Jack Del Rio
-2014,DEN,2014_03_DEN_SEA,Adam Gase,Jack Del Rio
-2014,DEN,2014_05_ARI_DEN,Adam Gase,Jack Del Rio
-2014,DEN,2014_06_DEN_NYJ,Adam Gase,Jack Del Rio
-2014,DEN,2014_07_SF_DEN,Adam Gase,Jack Del Rio
-2014,DEN,2014_08_SD_DEN,Adam Gase,Jack Del Rio
-2014,DEN,2014_09_DEN_NE,Adam Gase,Jack Del Rio
-2014,DEN,2014_10_DEN_OAK,Adam Gase,Jack Del Rio
-2014,DEN,2014_11_DEN_STL,Adam Gase,Jack Del Rio
-2014,DEN,2014_12_MIA_DEN,Adam Gase,Jack Del Rio
-2014,DEN,2014_13_DEN_KC,Adam Gase,Jack Del Rio
-2014,DEN,2014_14_BUF_DEN,Adam Gase,Jack Del Rio
-2014,DEN,2014_15_DEN_SD,Adam Gase,Jack Del Rio
-2014,DEN,2014_16_DEN_CIN,Adam Gase,Jack Del Rio
-2014,DEN,2014_17_OAK_DEN,Adam Gase,Jack Del Rio
-2014,DEN,2014_19_IND_DEN,Adam Gase,Jack Del Rio
-2014,DET,2014_01_NYG_DET,Joe Lombardi,Teryl Austin
-2014,DET,2014_02_DET_CAR,Joe Lombardi,Teryl Austin
-2014,DET,2014_03_GB_DET,Joe Lombardi,Teryl Austin
-2014,DET,2014_04_DET_NYJ,Joe Lombardi,Teryl Austin
-2014,DET,2014_05_BUF_DET,Joe Lombardi,Teryl Austin
-2014,DET,2014_06_DET_MIN,Joe Lombardi,Teryl Austin
-2014,DET,2014_07_NO_DET,Joe Lombardi,Teryl Austin
-2014,DET,2014_08_DET_ATL,Joe Lombardi,Teryl Austin
-2014,DET,2014_10_MIA_DET,Joe Lombardi,Teryl Austin
-2014,DET,2014_11_DET_ARI,Joe Lombardi,Teryl Austin
-2014,DET,2014_12_DET_NE,Joe Lombardi,Teryl Austin
-2014,DET,2014_13_CHI_DET,Joe Lombardi,Teryl Austin
-2014,DET,2014_14_TB_DET,Joe Lombardi,Teryl Austin
-2014,DET,2014_15_MIN_DET,Joe Lombardi,Teryl Austin
-2014,DET,2014_16_DET_CHI,Joe Lombardi,Teryl Austin
-2014,DET,2014_17_DET_GB,Joe Lombardi,Teryl Austin
-2014,DET,2014_18_DET_DAL,Joe Lombardi,Teryl Austin
-2014,GB,2014_01_GB_SEA,Mike McCarthy,Dom Capers
-2014,GB,2014_02_NYJ_GB,Mike McCarthy,Dom Capers
-2014,GB,2014_03_GB_DET,Mike McCarthy,Dom Capers
-2014,GB,2014_04_GB_CHI,Mike McCarthy,Dom Capers
-2014,GB,2014_05_MIN_GB,Mike McCarthy,Dom Capers
-2014,GB,2014_06_GB_MIA,Mike McCarthy,Dom Capers
-2014,GB,2014_07_CAR_GB,Mike McCarthy,Dom Capers
-2014,GB,2014_08_GB_NO,Mike McCarthy,Dom Capers
-2014,GB,2014_10_CHI_GB,Mike McCarthy,Dom Capers
-2014,GB,2014_11_PHI_GB,Mike McCarthy,Dom Capers
-2014,GB,2014_12_GB_MIN,Mike McCarthy,Dom Capers
-2014,GB,2014_13_NE_GB,Mike McCarthy,Dom Capers
-2014,GB,2014_14_ATL_GB,Mike McCarthy,Dom Capers
-2014,GB,2014_15_GB_BUF,Mike McCarthy,Dom Capers
-2014,GB,2014_16_GB_TB,Mike McCarthy,Dom Capers
-2014,GB,2014_17_DET_GB,Mike McCarthy,Dom Capers
-2014,GB,2014_19_DAL_GB,Mike McCarthy,Dom Capers
-2014,GB,2014_20_GB_SEA,Mike McCarthy,Dom Capers
-2014,HOU,2014_01_WAS_HOU,Bill O'Brien,Romeo Crennel
-2014,HOU,2014_02_HOU_OAK,Bill O'Brien,Romeo Crennel
-2014,HOU,2014_03_HOU_NYG,Bill O'Brien,Romeo Crennel
-2014,HOU,2014_04_BUF_HOU,Bill O'Brien,Romeo Crennel
-2014,HOU,2014_05_HOU_DAL,Bill O'Brien,Romeo Crennel
-2014,HOU,2014_06_IND_HOU,Bill O'Brien,Romeo Crennel
-2014,HOU,2014_07_HOU_PIT,Bill O'Brien,Romeo Crennel
-2014,HOU,2014_08_HOU_TEN,Bill O'Brien,Romeo Crennel
-2014,HOU,2014_09_PHI_HOU,Bill O'Brien,Romeo Crennel
-2014,HOU,2014_11_HOU_CLE,Bill O'Brien,Romeo Crennel
-2014,HOU,2014_12_CIN_HOU,Bill O'Brien,Romeo Crennel
-2014,HOU,2014_13_TEN_HOU,Bill O'Brien,Romeo Crennel
-2014,HOU,2014_14_HOU_JAX,Bill O'Brien,Romeo Crennel
-2014,HOU,2014_15_HOU_IND,Bill O'Brien,Romeo Crennel
-2014,HOU,2014_16_BAL_HOU,Bill O'Brien,Romeo Crennel
-2014,HOU,2014_17_JAX_HOU,Bill O'Brien,Romeo Crennel
-2014,IND,2014_01_IND_DEN,Pep Hamilton,Greg Manusky
-2014,IND,2014_02_PHI_IND,Pep Hamilton,Greg Manusky
-2014,IND,2014_03_IND_JAX,Pep Hamilton,Greg Manusky
-2014,IND,2014_04_TEN_IND,Pep Hamilton,Greg Manusky
-2014,IND,2014_05_BAL_IND,Pep Hamilton,Greg Manusky
-2014,IND,2014_06_IND_HOU,Pep Hamilton,Greg Manusky
-2014,IND,2014_07_CIN_IND,Pep Hamilton,Greg Manusky
-2014,IND,2014_08_IND_PIT,Pep Hamilton,Greg Manusky
-2014,IND,2014_09_IND_NYG,Pep Hamilton,Greg Manusky
-2014,IND,2014_11_NE_IND,Pep Hamilton,Greg Manusky
-2014,IND,2014_12_JAX_IND,Pep Hamilton,Greg Manusky
-2014,IND,2014_13_WAS_IND,Pep Hamilton,Greg Manusky
-2014,IND,2014_14_IND_CLE,Pep Hamilton,Greg Manusky
-2014,IND,2014_15_HOU_IND,Pep Hamilton,Greg Manusky
-2014,IND,2014_16_IND_DAL,Pep Hamilton,Greg Manusky
-2014,IND,2014_17_IND_TEN,Pep Hamilton,Greg Manusky
-2014,IND,2014_18_CIN_IND,Pep Hamilton,Greg Manusky
-2014,IND,2014_19_IND_DEN,Pep Hamilton,Greg Manusky
-2014,IND,2014_20_IND_NE,Pep Hamilton,Greg Manusky
-2014,JAX,2014_01_JAX_PHI,Greg Olson,Bob Babich
-2014,JAX,2014_02_JAX_WAS,Greg Olson,Bob Babich
-2014,JAX,2014_03_IND_JAX,Greg Olson,Bob Babich
-2014,JAX,2014_04_JAX_SD,Greg Olson,Bob Babich
-2014,JAX,2014_05_PIT_JAX,Greg Olson,Bob Babich
-2014,JAX,2014_06_JAX_TEN,Greg Olson,Bob Babich
-2014,JAX,2014_07_CLE_JAX,Greg Olson,Bob Babich
-2014,JAX,2014_08_MIA_JAX,Greg Olson,Bob Babich
-2014,JAX,2014_09_JAX_CIN,Greg Olson,Bob Babich
-2014,JAX,2014_10_DAL_JAX,Greg Olson,Bob Babich
-2014,JAX,2014_12_JAX_IND,Greg Olson,Bob Babich
-2014,JAX,2014_13_NYG_JAX,Greg Olson,Bob Babich
-2014,JAX,2014_14_HOU_JAX,Greg Olson,Bob Babich
-2014,JAX,2014_15_JAX_BAL,Greg Olson,Bob Babich
-2014,JAX,2014_16_TEN_JAX,Greg Olson,Bob Babich
-2014,JAX,2014_17_JAX_HOU,Greg Olson,Bob Babich
-2014,KC,2014_01_TEN_KC,Andy Reid,Bob Sutton
-2014,KC,2014_02_KC_DEN,Andy Reid,Bob Sutton
-2014,KC,2014_03_KC_MIA,Andy Reid,Bob Sutton
-2014,KC,2014_04_NE_KC,Andy Reid,Bob Sutton
-2014,KC,2014_05_KC_SF,Andy Reid,Bob Sutton
-2014,KC,2014_07_KC_SD,Andy Reid,Bob Sutton
-2014,KC,2014_08_STL_KC,Andy Reid,Bob Sutton
-2014,KC,2014_09_NYJ_KC,Andy Reid,Bob Sutton
-2014,KC,2014_10_KC_BUF,Andy Reid,Bob Sutton
-2014,KC,2014_11_SEA_KC,Andy Reid,Bob Sutton
-2014,KC,2014_12_KC_OAK,Andy Reid,Bob Sutton
-2014,KC,2014_13_DEN_KC,Andy Reid,Bob Sutton
-2014,KC,2014_14_KC_ARI,Andy Reid,Bob Sutton
-2014,KC,2014_15_OAK_KC,Andy Reid,Bob Sutton
-2014,KC,2014_16_KC_PIT,Andy Reid,Bob Sutton
-2014,KC,2014_17_SD_KC,Andy Reid,Bob Sutton
-2014,LA,2014_01_MIN_STL,Brian Schottenheimer,Gregg Williams
-2014,LA,2014_02_STL_TB,Brian Schottenheimer,Gregg Williams
-2014,LA,2014_03_DAL_STL,Brian Schottenheimer,Gregg Williams
-2014,LA,2014_05_STL_PHI,Brian Schottenheimer,Gregg Williams
-2014,LA,2014_06_SF_STL,Brian Schottenheimer,Gregg Williams
-2014,LA,2014_07_SEA_STL,Brian Schottenheimer,Gregg Williams
-2014,LA,2014_08_STL_KC,Brian Schottenheimer,Gregg Williams
-2014,LA,2014_09_STL_SF,Brian Schottenheimer,Gregg Williams
-2014,LA,2014_10_STL_ARI,Brian Schottenheimer,Gregg Williams
-2014,LA,2014_11_DEN_STL,Brian Schottenheimer,Gregg Williams
-2014,LA,2014_12_STL_SD,Brian Schottenheimer,Gregg Williams
-2014,LA,2014_13_OAK_STL,Brian Schottenheimer,Gregg Williams
-2014,LA,2014_14_STL_WAS,Brian Schottenheimer,Gregg Williams
-2014,LA,2014_15_ARI_STL,Brian Schottenheimer,Gregg Williams
-2014,LA,2014_16_NYG_STL,Brian Schottenheimer,Gregg Williams
-2014,LA,2014_17_STL_SEA,Brian Schottenheimer,Gregg Williams
-2014,LAC,2014_01_SD_ARI,Mike McCoy,John Pagano
-2014,LAC,2014_02_SEA_SD,Frank Reich,John Pagano
-2014,LAC,2014_03_SD_BUF,Frank Reich,John Pagano
-2014,LAC,2014_04_JAX_SD,Frank Reich,John Pagano
-2014,LAC,2014_05_NYJ_SD,Frank Reich,John Pagano
-2014,LAC,2014_06_SD_OAK,Frank Reich,John Pagano
-2014,LAC,2014_07_KC_SD,Frank Reich,John Pagano
-2014,LAC,2014_08_SD_DEN,Frank Reich,John Pagano
-2014,LAC,2014_09_SD_MIA,Frank Reich,John Pagano
-2014,LAC,2014_11_OAK_SD,Frank Reich,John Pagano
-2014,LAC,2014_12_STL_SD,Frank Reich,John Pagano
-2014,LAC,2014_13_SD_BAL,Frank Reich,John Pagano
-2014,LAC,2014_14_NE_SD,Frank Reich,John Pagano
-2014,LAC,2014_15_DEN_SD,Frank Reich,John Pagano
-2014,LAC,2014_16_SD_SF,Frank Reich,John Pagano
-2014,LAC,2014_17_SD_KC,Frank Reich,John Pagano
-2014,LV,2014_01_OAK_NYJ,Greg Olson,Jason Tarver
-2014,LV,2014_02_HOU_OAK,Greg Olson,Jason Tarver
-2014,LV,2014_03_OAK_NE,Greg Olson,Jason Tarver
-2014,LV,2014_04_MIA_OAK,Greg Olson,Jason Tarver
-2014,LV,2014_06_SD_OAK,Greg Olson,Jason Tarver
-2014,LV,2014_07_ARI_OAK,Greg Olson,Jason Tarver
-2014,LV,2014_08_OAK_CLE,Greg Olson,Jason Tarver
-2014,LV,2014_09_OAK_SEA,Greg Olson,Jason Tarver
-2014,LV,2014_10_DEN_OAK,Greg Olson,Jason Tarver
-2014,LV,2014_11_OAK_SD,Greg Olson,Jason Tarver
-2014,LV,2014_12_KC_OAK,Greg Olson,Jason Tarver
-2014,LV,2014_13_OAK_STL,Greg Olson,Jason Tarver
-2014,LV,2014_14_SF_OAK,Greg Olson,Jason Tarver
-2014,LV,2014_15_OAK_KC,Greg Olson,Jason Tarver
-2014,LV,2014_16_BUF_OAK,Greg Olson,Jason Tarver
-2014,LV,2014_17_OAK_DEN,Greg Olson,Jason Tarver
-2014,MIA,2014_01_NE_MIA,Bill Lazor,Kevin Coyle
-2014,MIA,2014_02_MIA_BUF,Bill Lazor,Kevin Coyle
-2014,MIA,2014_03_KC_MIA,Bill Lazor,Kevin Coyle
-2014,MIA,2014_04_MIA_OAK,Bill Lazor,Kevin Coyle
-2014,MIA,2014_06_GB_MIA,Bill Lazor,Kevin Coyle
-2014,MIA,2014_07_MIA_CHI,Bill Lazor,Kevin Coyle
-2014,MIA,2014_08_MIA_JAX,Bill Lazor,Kevin Coyle
-2014,MIA,2014_09_SD_MIA,Bill Lazor,Kevin Coyle
-2014,MIA,2014_10_MIA_DET,Bill Lazor,Kevin Coyle
-2014,MIA,2014_11_BUF_MIA,Bill Lazor,Kevin Coyle
-2014,MIA,2014_12_MIA_DEN,Bill Lazor,Kevin Coyle
-2014,MIA,2014_13_MIA_NYJ,Bill Lazor,Kevin Coyle
-2014,MIA,2014_14_BAL_MIA,Bill Lazor,Kevin Coyle
-2014,MIA,2014_15_MIA_NE,Bill Lazor,Kevin Coyle
-2014,MIA,2014_16_MIN_MIA,Bill Lazor,Kevin Coyle
-2014,MIA,2014_17_NYJ_MIA,Bill Lazor,Kevin Coyle
-2014,MIN,2014_01_MIN_STL,Norv Turner,Mike Zimmer
-2014,MIN,2014_02_NE_MIN,Norv Turner,Mike Zimmer
-2014,MIN,2014_03_MIN_NO,Norv Turner,Mike Zimmer
-2014,MIN,2014_04_ATL_MIN,Norv Turner,Mike Zimmer
-2014,MIN,2014_05_MIN_GB,Norv Turner,Mike Zimmer
-2014,MIN,2014_06_DET_MIN,Norv Turner,Mike Zimmer
-2014,MIN,2014_07_MIN_BUF,Norv Turner,Mike Zimmer
-2014,MIN,2014_08_MIN_TB,Norv Turner,Mike Zimmer
-2014,MIN,2014_09_WAS_MIN,Norv Turner,Mike Zimmer
-2014,MIN,2014_11_MIN_CHI,Norv Turner,Mike Zimmer
-2014,MIN,2014_12_GB_MIN,Norv Turner,Mike Zimmer
-2014,MIN,2014_13_CAR_MIN,Norv Turner,Mike Zimmer
-2014,MIN,2014_14_NYJ_MIN,Norv Turner,Mike Zimmer
-2014,MIN,2014_15_MIN_DET,Norv Turner,Mike Zimmer
-2014,MIN,2014_16_MIN_MIA,Norv Turner,Mike Zimmer
-2014,MIN,2014_17_CHI_MIN,Norv Turner,Mike Zimmer
-2014,NE,2014_01_NE_MIA,Josh McDaniels,Matt Patricia
-2014,NE,2014_02_NE_MIN,Josh McDaniels,Matt Patricia
-2014,NE,2014_03_OAK_NE,Josh McDaniels,Matt Patricia
-2014,NE,2014_04_NE_KC,Josh McDaniels,Matt Patricia
-2014,NE,2014_05_CIN_NE,Josh McDaniels,Matt Patricia
-2014,NE,2014_06_NE_BUF,Josh McDaniels,Matt Patricia
-2014,NE,2014_07_NYJ_NE,Josh McDaniels,Matt Patricia
-2014,NE,2014_08_CHI_NE,Josh McDaniels,Matt Patricia
-2014,NE,2014_09_DEN_NE,Josh McDaniels,Matt Patricia
-2014,NE,2014_11_NE_IND,Josh McDaniels,Matt Patricia
-2014,NE,2014_12_DET_NE,Josh McDaniels,Matt Patricia
-2014,NE,2014_13_NE_GB,Josh McDaniels,Matt Patricia
-2014,NE,2014_14_NE_SD,Josh McDaniels,Matt Patricia
-2014,NE,2014_15_MIA_NE,Josh McDaniels,Matt Patricia
-2014,NE,2014_16_NE_NYJ,Josh McDaniels,Matt Patricia
-2014,NE,2014_17_BUF_NE,Josh McDaniels,Matt Patricia
-2014,NE,2014_19_BAL_NE,Josh McDaniels,Matt Patricia
-2014,NE,2014_20_IND_NE,Josh McDaniels,Matt Patricia
-2014,NE,2014_21_NE_SEA,Josh McDaniels,Matt Patricia
-2014,NO,2014_01_NO_ATL,Sean Payton,Rob Ryan
-2014,NO,2014_02_NO_CLE,Sean Payton,Rob Ryan
-2014,NO,2014_03_MIN_NO,Sean Payton,Rob Ryan
-2014,NO,2014_04_NO_DAL,Sean Payton,Rob Ryan
-2014,NO,2014_05_TB_NO,Sean Payton,Rob Ryan
-2014,NO,2014_07_NO_DET,Sean Payton,Rob Ryan
-2014,NO,2014_08_GB_NO,Sean Payton,Rob Ryan
-2014,NO,2014_09_NO_CAR,Sean Payton,Rob Ryan
-2014,NO,2014_10_SF_NO,Sean Payton,Rob Ryan
-2014,NO,2014_11_CIN_NO,Sean Payton,Rob Ryan
-2014,NO,2014_12_BAL_NO,Sean Payton,Rob Ryan
-2014,NO,2014_13_NO_PIT,Sean Payton,Rob Ryan
-2014,NO,2014_14_CAR_NO,Sean Payton,Rob Ryan
-2014,NO,2014_15_NO_CHI,Sean Payton,Rob Ryan
-2014,NO,2014_16_ATL_NO,Sean Payton,Rob Ryan
-2014,NO,2014_17_NO_TB,Sean Payton,Rob Ryan
-2014,NYG,2014_01_NYG_DET,Ben McAdoo,Perry Fewell
-2014,NYG,2014_02_ARI_NYG,Ben McAdoo,Perry Fewell
-2014,NYG,2014_03_HOU_NYG,Ben McAdoo,Perry Fewell
-2014,NYG,2014_04_NYG_WAS,Ben McAdoo,Perry Fewell
-2014,NYG,2014_05_ATL_NYG,Ben McAdoo,Perry Fewell
-2014,NYG,2014_06_NYG_PHI,Ben McAdoo,Perry Fewell
-2014,NYG,2014_07_NYG_DAL,Ben McAdoo,Perry Fewell
-2014,NYG,2014_09_IND_NYG,Ben McAdoo,Perry Fewell
-2014,NYG,2014_10_NYG_SEA,Ben McAdoo,Perry Fewell
-2014,NYG,2014_11_SF_NYG,Ben McAdoo,Perry Fewell
-2014,NYG,2014_12_DAL_NYG,Ben McAdoo,Perry Fewell
-2014,NYG,2014_13_NYG_JAX,Ben McAdoo,Perry Fewell
-2014,NYG,2014_14_NYG_TEN,Ben McAdoo,Perry Fewell
-2014,NYG,2014_15_WAS_NYG,Ben McAdoo,Perry Fewell
-2014,NYG,2014_16_NYG_STL,Ben McAdoo,Perry Fewell
-2014,NYG,2014_17_PHI_NYG,Ben McAdoo,Perry Fewell
-2014,NYJ,2014_01_OAK_NYJ,Marty Mornhinweg,Dennis Thurman
-2014,NYJ,2014_02_NYJ_GB,Marty Mornhinweg,Dennis Thurman
-2014,NYJ,2014_03_CHI_NYJ,Marty Mornhinweg,Dennis Thurman
-2014,NYJ,2014_04_DET_NYJ,Marty Mornhinweg,Dennis Thurman
-2014,NYJ,2014_05_NYJ_SD,Marty Mornhinweg,Dennis Thurman
-2014,NYJ,2014_06_DEN_NYJ,Marty Mornhinweg,Dennis Thurman
-2014,NYJ,2014_07_NYJ_NE,Marty Mornhinweg,Dennis Thurman
-2014,NYJ,2014_08_BUF_NYJ,Marty Mornhinweg,Dennis Thurman
-2014,NYJ,2014_09_NYJ_KC,Marty Mornhinweg,Dennis Thurman
-2014,NYJ,2014_10_PIT_NYJ,Marty Mornhinweg,Dennis Thurman
-2014,NYJ,2014_12_NYJ_BUF,Marty Mornhinweg,Dennis Thurman
-2014,NYJ,2014_13_MIA_NYJ,Marty Mornhinweg,Dennis Thurman
-2014,NYJ,2014_14_NYJ_MIN,Marty Mornhinweg,Dennis Thurman
-2014,NYJ,2014_15_NYJ_TEN,Marty Mornhinweg,Dennis Thurman
-2014,NYJ,2014_16_NE_NYJ,Marty Mornhinweg,Dennis Thurman
-2014,NYJ,2014_17_NYJ_MIA,Marty Mornhinweg,Dennis Thurman
-2014,PHI,2014_01_JAX_PHI,Chip Kelly,Billy Davis
-2014,PHI,2014_02_PHI_IND,Chip Kelly,Billy Davis
-2014,PHI,2014_03_WAS_PHI,Chip Kelly,Billy Davis
-2014,PHI,2014_04_PHI_SF,Chip Kelly,Billy Davis
-2014,PHI,2014_05_STL_PHI,Chip Kelly,Billy Davis
-2014,PHI,2014_06_NYG_PHI,Chip Kelly,Billy Davis
-2014,PHI,2014_08_PHI_ARI,Chip Kelly,Billy Davis
-2014,PHI,2014_09_PHI_HOU,Chip Kelly,Billy Davis
-2014,PHI,2014_10_CAR_PHI,Chip Kelly,Billy Davis
-2014,PHI,2014_11_PHI_GB,Chip Kelly,Billy Davis
-2014,PHI,2014_12_TEN_PHI,Chip Kelly,Billy Davis
-2014,PHI,2014_13_PHI_DAL,Chip Kelly,Billy Davis
-2014,PHI,2014_14_SEA_PHI,Chip Kelly,Billy Davis
-2014,PHI,2014_15_DAL_PHI,Chip Kelly,Billy Davis
-2014,PHI,2014_16_PHI_WAS,Chip Kelly,Billy Davis
-2014,PHI,2014_17_PHI_NYG,Chip Kelly,Billy Davis
-2014,PIT,2014_01_CLE_PIT,Todd Haley,Mike Tomlin
-2014,PIT,2014_02_PIT_BAL,Todd Haley,Mike Tomlin
-2014,PIT,2014_03_PIT_CAR,Todd Haley,Mike Tomlin
-2014,PIT,2014_04_TB_PIT,Todd Haley,Mike Tomlin
-2014,PIT,2014_05_PIT_JAX,Todd Haley,Mike Tomlin
-2014,PIT,2014_06_PIT_CLE,Todd Haley,Mike Tomlin
-2014,PIT,2014_07_HOU_PIT,Todd Haley,Mike Tomlin
-2014,PIT,2014_08_IND_PIT,Todd Haley,Mike Tomlin
-2014,PIT,2014_09_BAL_PIT,Todd Haley,Mike Tomlin
-2014,PIT,2014_10_PIT_NYJ,Todd Haley,Mike Tomlin
-2014,PIT,2014_11_PIT_TEN,Todd Haley,Mike Tomlin
-2014,PIT,2014_13_NO_PIT,Todd Haley,Mike Tomlin
-2014,PIT,2014_14_PIT_CIN,Todd Haley,Mike Tomlin
-2014,PIT,2014_15_PIT_ATL,Todd Haley,Mike Tomlin
-2014,PIT,2014_16_KC_PIT,Todd Haley,Mike Tomlin
-2014,PIT,2014_17_CIN_PIT,Todd Haley,Mike Tomlin
-2014,PIT,2014_18_BAL_PIT,Todd Haley,Mike Tomlin
-2014,SEA,2014_01_GB_SEA,Darrell Bevell,Dan Quinn
-2014,SEA,2014_02_SEA_SD,Darrell Bevell,Dan Quinn
-2014,SEA,2014_03_DEN_SEA,Darrell Bevell,Dan Quinn
-2014,SEA,2014_05_SEA_WAS,Darrell Bevell,Dan Quinn
-2014,SEA,2014_06_DAL_SEA,Darrell Bevell,Dan Quinn
-2014,SEA,2014_07_SEA_STL,Darrell Bevell,Dan Quinn
-2014,SEA,2014_08_SEA_CAR,Darrell Bevell,Dan Quinn
-2014,SEA,2014_09_OAK_SEA,Darrell Bevell,Dan Quinn
-2014,SEA,2014_10_NYG_SEA,Darrell Bevell,Dan Quinn
-2014,SEA,2014_11_SEA_KC,Darrell Bevell,Dan Quinn
-2014,SEA,2014_12_ARI_SEA,Darrell Bevell,Dan Quinn
-2014,SEA,2014_13_SEA_SF,Darrell Bevell,Dan Quinn
-2014,SEA,2014_14_SEA_PHI,Darrell Bevell,Dan Quinn
-2014,SEA,2014_15_SF_SEA,Darrell Bevell,Dan Quinn
-2014,SEA,2014_16_SEA_ARI,Darrell Bevell,Dan Quinn
-2014,SEA,2014_17_STL_SEA,Darrell Bevell,Dan Quinn
-2014,SEA,2014_19_CAR_SEA,Darrell Bevell,Dan Quinn
-2014,SEA,2014_20_GB_SEA,Darrell Bevell,Dan Quinn
-2014,SEA,2014_21_NE_SEA,Darrell Bevell,Dan Quinn
-2014,SF,2014_01_SF_DAL,Greg Roman,Vic Fangio
-2014,SF,2014_02_CHI_SF,Greg Roman,Vic Fangio
-2014,SF,2014_03_SF_ARI,Greg Roman,Vic Fangio
-2014,SF,2014_04_PHI_SF,Greg Roman,Vic Fangio
-2014,SF,2014_05_KC_SF,Greg Roman,Vic Fangio
-2014,SF,2014_06_SF_STL,Greg Roman,Vic Fangio
-2014,SF,2014_07_SF_DEN,Greg Roman,Vic Fangio
-2014,SF,2014_09_STL_SF,Greg Roman,Vic Fangio
-2014,SF,2014_10_SF_NO,Greg Roman,Vic Fangio
-2014,SF,2014_11_SF_NYG,Greg Roman,Vic Fangio
-2014,SF,2014_12_WAS_SF,Greg Roman,Vic Fangio
-2014,SF,2014_13_SEA_SF,Greg Roman,Vic Fangio
-2014,SF,2014_14_SF_OAK,Greg Roman,Vic Fangio
-2014,SF,2014_15_SF_SEA,Greg Roman,Vic Fangio
-2014,SF,2014_16_SD_SF,Greg Roman,Vic Fangio
-2014,SF,2014_17_ARI_SF,Greg Roman,Vic Fangio
-2014,TB,2014_01_CAR_TB,Jeff Tedford,Leslie Frazier
-2014,TB,2014_02_STL_TB,Jeff Tedford,Leslie Frazier
-2014,TB,2014_03_TB_ATL,Jeff Tedford,Leslie Frazier
-2014,TB,2014_04_TB_PIT,Jeff Tedford,Leslie Frazier
-2014,TB,2014_05_TB_NO,Jeff Tedford,Leslie Frazier
-2014,TB,2014_06_BAL_TB,Jeff Tedford,Leslie Frazier
-2014,TB,2014_08_MIN_TB,Jeff Tedford,Leslie Frazier
-2014,TB,2014_09_TB_CLE,Jeff Tedford,Leslie Frazier
-2014,TB,2014_10_ATL_TB,Jeff Tedford,Leslie Frazier
-2014,TB,2014_11_TB_WAS,Jeff Tedford,Leslie Frazier
-2014,TB,2014_12_TB_CHI,Jeff Tedford,Leslie Frazier
-2014,TB,2014_13_CIN_TB,Jeff Tedford,Leslie Frazier
-2014,TB,2014_14_TB_DET,Jeff Tedford,Leslie Frazier
-2014,TB,2014_15_TB_CAR,Jeff Tedford,Leslie Frazier
-2014,TB,2014_16_GB_TB,Jeff Tedford,Leslie Frazier
-2014,TB,2014_17_NO_TB,Jeff Tedford,Leslie Frazier
-2014,TEN,2014_01_TEN_KC,Ken Whisenhunt,Ray Horton
-2014,TEN,2014_02_DAL_TEN,Ken Whisenhunt,Ray Horton
-2014,TEN,2014_03_TEN_CIN,Ken Whisenhunt,Ray Horton
-2014,TEN,2014_04_TEN_IND,Ken Whisenhunt,Ray Horton
-2014,TEN,2014_05_CLE_TEN,Ken Whisenhunt,Ray Horton
-2014,TEN,2014_06_JAX_TEN,Ken Whisenhunt,Ray Horton
-2014,TEN,2014_07_TEN_WAS,Ken Whisenhunt,Ray Horton
-2014,TEN,2014_08_HOU_TEN,Ken Whisenhunt,Ray Horton
-2014,TEN,2014_10_TEN_BAL,Ken Whisenhunt,Ray Horton
-2014,TEN,2014_11_PIT_TEN,Ken Whisenhunt,Ray Horton
-2014,TEN,2014_12_TEN_PHI,Ken Whisenhunt,Ray Horton
-2014,TEN,2014_13_TEN_HOU,Ken Whisenhunt,Ray Horton
-2014,TEN,2014_14_NYG_TEN,Ken Whisenhunt,Ray Horton
-2014,TEN,2014_15_NYJ_TEN,Ken Whisenhunt,Ray Horton
-2014,TEN,2014_16_TEN_JAX,Ken Whisenhunt,Ray Horton
-2014,TEN,2014_17_IND_TEN,Ken Whisenhunt,Ray Horton
-2014,WAS,2014_01_WAS_HOU,Jay Gruden,Jim Haslett
-2014,WAS,2014_02_JAX_WAS,Jay Gruden,Jim Haslett
-2014,WAS,2014_03_WAS_PHI,Jay Gruden,Jim Haslett
-2014,WAS,2014_04_NYG_WAS,Jay Gruden,Jim Haslett
-2014,WAS,2014_05_SEA_WAS,Jay Gruden,Jim Haslett
-2014,WAS,2014_06_WAS_ARI,Jay Gruden,Jim Haslett
-2014,WAS,2014_07_TEN_WAS,Jay Gruden,Jim Haslett
-2014,WAS,2014_08_WAS_DAL,Jay Gruden,Jim Haslett
-2014,WAS,2014_09_WAS_MIN,Jay Gruden,Jim Haslett
-2014,WAS,2014_11_TB_WAS,Jay Gruden,Jim Haslett
-2014,WAS,2014_12_WAS_SF,Jay Gruden,Jim Haslett
-2014,WAS,2014_13_WAS_IND,Jay Gruden,Jim Haslett
-2014,WAS,2014_14_STL_WAS,Jay Gruden,Jim Haslett
-2014,WAS,2014_15_WAS_NYG,Jay Gruden,Jim Haslett
-2014,WAS,2014_16_PHI_WAS,Jay Gruden,Jim Haslett
-2014,WAS,2014_17_DAL_WAS,Jay Gruden,Jim Haslett
 2015,ARI,2015_01_NO_ARI,Bruce Arians,James Bettcher
 2015,ARI,2015_02_ARI_CHI,Bruce Arians,James Bettcher
 2015,ARI,2015_03_SF_ARI,Bruce Arians,James Bettcher
@@ -1085,522 +50,6 @@ season,team,game_id,off_play_caller,def_play_caller
 2015,ARI,2015_17_SEA_ARI,Bruce Arians,James Bettcher
 2015,ARI,2015_19_GB_ARI,Bruce Arians,James Bettcher
 2015,ARI,2015_20_ARI_CAR,Bruce Arians,James Bettcher
-2015,ATL,2015_01_PHI_ATL,Kyle Shanahan,Richard Smith
-2015,ATL,2015_02_ATL_NYG,Kyle Shanahan,Richard Smith
-2015,ATL,2015_03_ATL_DAL,Kyle Shanahan,Richard Smith
-2015,ATL,2015_04_HOU_ATL,Kyle Shanahan,Richard Smith
-2015,ATL,2015_05_WAS_ATL,Kyle Shanahan,Richard Smith
-2015,ATL,2015_06_ATL_NO,Kyle Shanahan,Richard Smith
-2015,ATL,2015_07_ATL_TEN,Kyle Shanahan,Richard Smith
-2015,ATL,2015_08_TB_ATL,Kyle Shanahan,Richard Smith
-2015,ATL,2015_09_ATL_SF,Kyle Shanahan,Richard Smith
-2015,ATL,2015_11_IND_ATL,Kyle Shanahan,Richard Smith
-2015,ATL,2015_12_MIN_ATL,Kyle Shanahan,Richard Smith
-2015,ATL,2015_13_ATL_TB,Kyle Shanahan,Richard Smith
-2015,ATL,2015_14_ATL_CAR,Kyle Shanahan,Richard Smith
-2015,ATL,2015_15_ATL_JAX,Kyle Shanahan,Richard Smith
-2015,ATL,2015_16_CAR_ATL,Kyle Shanahan,Richard Smith
-2015,ATL,2015_17_NO_ATL,Kyle Shanahan,Richard Smith
-2015,BAL,2015_01_BAL_DEN,Marc Trestman,Dean Pees
-2015,BAL,2015_02_BAL_OAK,Marc Trestman,Dean Pees
-2015,BAL,2015_03_CIN_BAL,Marc Trestman,Dean Pees
-2015,BAL,2015_04_BAL_PIT,Marc Trestman,Dean Pees
-2015,BAL,2015_05_CLE_BAL,Marc Trestman,Dean Pees
-2015,BAL,2015_06_BAL_SF,Marc Trestman,Dean Pees
-2015,BAL,2015_07_BAL_ARI,Marc Trestman,Dean Pees
-2015,BAL,2015_08_SD_BAL,Marc Trestman,Dean Pees
-2015,BAL,2015_10_JAX_BAL,Marc Trestman,Dean Pees
-2015,BAL,2015_11_STL_BAL,Marc Trestman,Dean Pees
-2015,BAL,2015_12_BAL_CLE,Marc Trestman,Dean Pees
-2015,BAL,2015_13_BAL_MIA,Marc Trestman,Dean Pees
-2015,BAL,2015_14_SEA_BAL,Marc Trestman,Dean Pees
-2015,BAL,2015_15_KC_BAL,Marc Trestman,Dean Pees
-2015,BAL,2015_16_PIT_BAL,Marc Trestman,Dean Pees
-2015,BAL,2015_17_BAL_CIN,Marc Trestman,Dean Pees
-2015,BUF,2015_01_IND_BUF,Greg Roman,Dennis Thurman
-2015,BUF,2015_02_NE_BUF,Greg Roman,Dennis Thurman
-2015,BUF,2015_03_BUF_MIA,Greg Roman,Dennis Thurman
-2015,BUF,2015_04_NYG_BUF,Greg Roman,Dennis Thurman
-2015,BUF,2015_05_BUF_TEN,Greg Roman,Dennis Thurman
-2015,BUF,2015_06_CIN_BUF,Greg Roman,Dennis Thurman
-2015,BUF,2015_07_BUF_JAX,Greg Roman,Dennis Thurman
-2015,BUF,2015_09_MIA_BUF,Greg Roman,Dennis Thurman
-2015,BUF,2015_10_BUF_NYJ,Greg Roman,Dennis Thurman
-2015,BUF,2015_11_BUF_NE,Greg Roman,Dennis Thurman
-2015,BUF,2015_12_BUF_KC,Greg Roman,Dennis Thurman
-2015,BUF,2015_13_HOU_BUF,Greg Roman,Dennis Thurman
-2015,BUF,2015_14_BUF_PHI,Greg Roman,Dennis Thurman
-2015,BUF,2015_15_BUF_WAS,Greg Roman,Dennis Thurman
-2015,BUF,2015_16_DAL_BUF,Greg Roman,Dennis Thurman
-2015,BUF,2015_17_NYJ_BUF,Greg Roman,Dennis Thurman
-2015,CAR,2015_01_CAR_JAX,Mike Shula,Sean McDermott
-2015,CAR,2015_02_HOU_CAR,Mike Shula,Sean McDermott
-2015,CAR,2015_03_NO_CAR,Mike Shula,Sean McDermott
-2015,CAR,2015_04_CAR_TB,Mike Shula,Sean McDermott
-2015,CAR,2015_06_CAR_SEA,Mike Shula,Sean McDermott
-2015,CAR,2015_07_PHI_CAR,Mike Shula,Sean McDermott
-2015,CAR,2015_08_IND_CAR,Mike Shula,Sean McDermott
-2015,CAR,2015_09_GB_CAR,Mike Shula,Sean McDermott
-2015,CAR,2015_10_CAR_TEN,Mike Shula,Sean McDermott
-2015,CAR,2015_11_WAS_CAR,Mike Shula,Sean McDermott
-2015,CAR,2015_12_CAR_DAL,Mike Shula,Sean McDermott
-2015,CAR,2015_13_CAR_NO,Mike Shula,Sean McDermott
-2015,CAR,2015_14_ATL_CAR,Mike Shula,Sean McDermott
-2015,CAR,2015_15_CAR_NYG,Mike Shula,Sean McDermott
-2015,CAR,2015_16_CAR_ATL,Mike Shula,Sean McDermott
-2015,CAR,2015_17_TB_CAR,Mike Shula,Sean McDermott
-2015,CAR,2015_19_SEA_CAR,Mike Shula,Sean McDermott
-2015,CAR,2015_20_ARI_CAR,Mike Shula,Sean McDermott
-2015,CAR,2015_21_CAR_DEN,Mike Shula,Sean McDermott
-2015,CHI,2015_01_GB_CHI,Adam Gase,Vic Fangio
-2015,CHI,2015_02_ARI_CHI,Adam Gase,Vic Fangio
-2015,CHI,2015_03_CHI_SEA,Adam Gase,Vic Fangio
-2015,CHI,2015_04_OAK_CHI,Adam Gase,Vic Fangio
-2015,CHI,2015_05_CHI_KC,Adam Gase,Vic Fangio
-2015,CHI,2015_06_CHI_DET,Adam Gase,Vic Fangio
-2015,CHI,2015_08_MIN_CHI,Adam Gase,Vic Fangio
-2015,CHI,2015_09_CHI_SD,Adam Gase,Vic Fangio
-2015,CHI,2015_10_CHI_STL,Adam Gase,Vic Fangio
-2015,CHI,2015_11_DEN_CHI,Adam Gase,Vic Fangio
-2015,CHI,2015_12_CHI_GB,Adam Gase,Vic Fangio
-2015,CHI,2015_13_SF_CHI,Adam Gase,Vic Fangio
-2015,CHI,2015_14_WAS_CHI,Adam Gase,Vic Fangio
-2015,CHI,2015_15_CHI_MIN,Adam Gase,Vic Fangio
-2015,CHI,2015_16_CHI_TB,Adam Gase,Vic Fangio
-2015,CHI,2015_17_DET_CHI,Adam Gase,Vic Fangio
-2015,CIN,2015_01_CIN_OAK,Hue Jackson,Paul Guenther
-2015,CIN,2015_02_SD_CIN,Hue Jackson,Paul Guenther
-2015,CIN,2015_03_CIN_BAL,Hue Jackson,Paul Guenther
-2015,CIN,2015_04_KC_CIN,Hue Jackson,Paul Guenther
-2015,CIN,2015_05_SEA_CIN,Hue Jackson,Paul Guenther
-2015,CIN,2015_06_CIN_BUF,Hue Jackson,Paul Guenther
-2015,CIN,2015_08_CIN_PIT,Hue Jackson,Paul Guenther
-2015,CIN,2015_09_CLE_CIN,Hue Jackson,Paul Guenther
-2015,CIN,2015_10_HOU_CIN,Hue Jackson,Paul Guenther
-2015,CIN,2015_11_CIN_ARI,Hue Jackson,Paul Guenther
-2015,CIN,2015_12_STL_CIN,Hue Jackson,Paul Guenther
-2015,CIN,2015_13_CIN_CLE,Hue Jackson,Paul Guenther
-2015,CIN,2015_14_PIT_CIN,Hue Jackson,Paul Guenther
-2015,CIN,2015_15_CIN_SF,Hue Jackson,Paul Guenther
-2015,CIN,2015_16_CIN_DEN,Hue Jackson,Paul Guenther
-2015,CIN,2015_17_BAL_CIN,Hue Jackson,Paul Guenther
-2015,CIN,2015_18_PIT_CIN,Hue Jackson,Paul Guenther
-2015,CLE,2015_01_CLE_NYJ,John DeFilippo,Jim O'Neil
-2015,CLE,2015_02_TEN_CLE,John DeFilippo,Jim O'Neil
-2015,CLE,2015_03_OAK_CLE,John DeFilippo,Jim O'Neil
-2015,CLE,2015_04_CLE_SD,John DeFilippo,Jim O'Neil
-2015,CLE,2015_05_CLE_BAL,John DeFilippo,Jim O'Neil
-2015,CLE,2015_06_DEN_CLE,John DeFilippo,Jim O'Neil
-2015,CLE,2015_07_CLE_STL,John DeFilippo,Jim O'Neil
-2015,CLE,2015_08_ARI_CLE,John DeFilippo,Jim O'Neil
-2015,CLE,2015_09_CLE_CIN,John DeFilippo,Jim O'Neil
-2015,CLE,2015_10_CLE_PIT,John DeFilippo,Jim O'Neil
-2015,CLE,2015_12_BAL_CLE,John DeFilippo,Jim O'Neil
-2015,CLE,2015_13_CIN_CLE,John DeFilippo,Jim O'Neil
-2015,CLE,2015_14_SF_CLE,John DeFilippo,Jim O'Neil
-2015,CLE,2015_15_CLE_SEA,John DeFilippo,Jim O'Neil
-2015,CLE,2015_16_CLE_KC,John DeFilippo,Jim O'Neil
-2015,CLE,2015_17_PIT_CLE,John DeFilippo,Jim O'Neil
-2015,DAL,2015_01_NYG_DAL,Scott Linehan,Rod Marinelli
-2015,DAL,2015_02_DAL_PHI,Scott Linehan,Rod Marinelli
-2015,DAL,2015_03_ATL_DAL,Scott Linehan,Rod Marinelli
-2015,DAL,2015_04_DAL_NO,Scott Linehan,Rod Marinelli
-2015,DAL,2015_05_NE_DAL,Scott Linehan,Rod Marinelli
-2015,DAL,2015_07_DAL_NYG,Scott Linehan,Rod Marinelli
-2015,DAL,2015_08_SEA_DAL,Scott Linehan,Rod Marinelli
-2015,DAL,2015_09_PHI_DAL,Scott Linehan,Rod Marinelli
-2015,DAL,2015_10_DAL_TB,Scott Linehan,Rod Marinelli
-2015,DAL,2015_11_DAL_MIA,Scott Linehan,Rod Marinelli
-2015,DAL,2015_12_CAR_DAL,Scott Linehan,Rod Marinelli
-2015,DAL,2015_13_DAL_WAS,Scott Linehan,Rod Marinelli
-2015,DAL,2015_14_DAL_GB,Scott Linehan,Rod Marinelli
-2015,DAL,2015_15_NYJ_DAL,Scott Linehan,Rod Marinelli
-2015,DAL,2015_16_DAL_BUF,Scott Linehan,Rod Marinelli
-2015,DAL,2015_17_WAS_DAL,Scott Linehan,Rod Marinelli
-2015,DEN,2015_01_BAL_DEN,Gary Kubiak,Wade Phillips
-2015,DEN,2015_02_DEN_KC,Gary Kubiak,Wade Phillips
-2015,DEN,2015_03_DEN_DET,Gary Kubiak,Wade Phillips
-2015,DEN,2015_04_MIN_DEN,Gary Kubiak,Wade Phillips
-2015,DEN,2015_05_DEN_OAK,Gary Kubiak,Wade Phillips
-2015,DEN,2015_06_DEN_CLE,Gary Kubiak,Wade Phillips
-2015,DEN,2015_08_GB_DEN,Gary Kubiak,Wade Phillips
-2015,DEN,2015_09_DEN_IND,Gary Kubiak,Wade Phillips
-2015,DEN,2015_10_KC_DEN,Gary Kubiak,Wade Phillips
-2015,DEN,2015_11_DEN_CHI,Gary Kubiak,Wade Phillips
-2015,DEN,2015_12_NE_DEN,Gary Kubiak,Wade Phillips
-2015,DEN,2015_13_DEN_SD,Gary Kubiak,Wade Phillips
-2015,DEN,2015_14_OAK_DEN,Gary Kubiak,Wade Phillips
-2015,DEN,2015_15_DEN_PIT,Gary Kubiak,Wade Phillips
-2015,DEN,2015_16_CIN_DEN,Gary Kubiak,Wade Phillips
-2015,DEN,2015_17_SD_DEN,Gary Kubiak,Wade Phillips
-2015,DEN,2015_19_PIT_DEN,Gary Kubiak,Wade Phillips
-2015,DEN,2015_20_NE_DEN,Gary Kubiak,Wade Phillips
-2015,DEN,2015_21_CAR_DEN,Gary Kubiak,Wade Phillips
-2015,DET,2015_01_DET_SD,Joe Lombardi,Teryl Austin
-2015,DET,2015_02_DET_MIN,Joe Lombardi,Teryl Austin
-2015,DET,2015_03_DEN_DET,Joe Lombardi,Teryl Austin
-2015,DET,2015_04_DET_SEA,Joe Lombardi,Teryl Austin
-2015,DET,2015_05_ARI_DET,Joe Lombardi,Teryl Austin
-2015,DET,2015_06_CHI_DET,Joe Lombardi,Teryl Austin
-2015,DET,2015_07_MIN_DET,Joe Lombardi,Teryl Austin
-2015,DET,2015_08_DET_KC,Jim Bob Cooter,Teryl Austin
-2015,DET,2015_10_DET_GB,Jim Bob Cooter,Teryl Austin
-2015,DET,2015_11_OAK_DET,Jim Bob Cooter,Teryl Austin
-2015,DET,2015_12_PHI_DET,Jim Bob Cooter,Teryl Austin
-2015,DET,2015_13_GB_DET,Jim Bob Cooter,Teryl Austin
-2015,DET,2015_14_DET_STL,Jim Bob Cooter,Teryl Austin
-2015,DET,2015_15_DET_NO,Jim Bob Cooter,Teryl Austin
-2015,DET,2015_16_SF_DET,Jim Bob Cooter,Teryl Austin
-2015,DET,2015_17_DET_CHI,Jim Bob Cooter,Teryl Austin
-2015,GB,2015_01_GB_CHI,Tom Clements,Dom Capers
-2015,GB,2015_02_SEA_GB,Tom Clements,Dom Capers
-2015,GB,2015_03_KC_GB,Tom Clements,Dom Capers
-2015,GB,2015_04_GB_SF,Tom Clements,Dom Capers
-2015,GB,2015_05_STL_GB,Tom Clements,Dom Capers
-2015,GB,2015_06_SD_GB,Tom Clements,Dom Capers
-2015,GB,2015_08_GB_DEN,Tom Clements,Dom Capers
-2015,GB,2015_09_GB_CAR,Tom Clements,Dom Capers
-2015,GB,2015_10_DET_GB,Tom Clements,Dom Capers
-2015,GB,2015_11_GB_MIN,Tom Clements,Dom Capers
-2015,GB,2015_12_CHI_GB,Tom Clements,Dom Capers
-2015,GB,2015_13_GB_DET,Mike McCarthy,Dom Capers
-2015,GB,2015_14_DAL_GB,Mike McCarthy,Dom Capers
-2015,GB,2015_15_GB_OAK,Mike McCarthy,Dom Capers
-2015,GB,2015_16_GB_ARI,Mike McCarthy,Dom Capers
-2015,GB,2015_17_MIN_GB,Mike McCarthy,Dom Capers
-2015,GB,2015_18_GB_WAS,Mike McCarthy,Dom Capers
-2015,GB,2015_19_GB_ARI,Mike McCarthy,Dom Capers
-2015,HOU,2015_01_KC_HOU,Bill O'Brien,Romeo Crennel
-2015,HOU,2015_02_HOU_CAR,Bill O'Brien,Romeo Crennel
-2015,HOU,2015_03_TB_HOU,Bill O'Brien,Romeo Crennel
-2015,HOU,2015_04_HOU_ATL,Bill O'Brien,Romeo Crennel
-2015,HOU,2015_05_IND_HOU,Bill O'Brien,Romeo Crennel
-2015,HOU,2015_06_HOU_JAX,Bill O'Brien,Romeo Crennel
-2015,HOU,2015_07_HOU_MIA,Bill O'Brien,Romeo Crennel
-2015,HOU,2015_08_TEN_HOU,Bill O'Brien,Romeo Crennel
-2015,HOU,2015_10_HOU_CIN,Bill O'Brien,Romeo Crennel
-2015,HOU,2015_11_NYJ_HOU,Bill O'Brien,Romeo Crennel
-2015,HOU,2015_12_NO_HOU,Bill O'Brien,Romeo Crennel
-2015,HOU,2015_13_HOU_BUF,Bill O'Brien,Romeo Crennel
-2015,HOU,2015_14_NE_HOU,Bill O'Brien,Romeo Crennel
-2015,HOU,2015_15_HOU_IND,Bill O'Brien,Romeo Crennel
-2015,HOU,2015_16_HOU_TEN,Bill O'Brien,Romeo Crennel
-2015,HOU,2015_17_JAX_HOU,Bill O'Brien,Romeo Crennel
-2015,HOU,2015_18_KC_HOU,Bill O'Brien,Romeo Crennel
-2015,IND,2015_01_IND_BUF,Rob Chudzinski,Greg Manusky
-2015,IND,2015_02_NYJ_IND,Rob Chudzinski,Greg Manusky
-2015,IND,2015_03_IND_TEN,Rob Chudzinski,Greg Manusky
-2015,IND,2015_04_JAX_IND,Rob Chudzinski,Greg Manusky
-2015,IND,2015_05_IND_HOU,Rob Chudzinski,Greg Manusky
-2015,IND,2015_06_NE_IND,Rob Chudzinski,Greg Manusky
-2015,IND,2015_07_NO_IND,Rob Chudzinski,Greg Manusky
-2015,IND,2015_08_IND_CAR,Rob Chudzinski,Greg Manusky
-2015,IND,2015_09_DEN_IND,Rob Chudzinski,Greg Manusky
-2015,IND,2015_11_IND_ATL,Rob Chudzinski,Greg Manusky
-2015,IND,2015_12_TB_IND,Rob Chudzinski,Greg Manusky
-2015,IND,2015_13_IND_PIT,Rob Chudzinski,Greg Manusky
-2015,IND,2015_14_IND_JAX,Rob Chudzinski,Greg Manusky
-2015,IND,2015_15_HOU_IND,Rob Chudzinski,Greg Manusky
-2015,IND,2015_16_IND_MIA,Rob Chudzinski,Greg Manusky
-2015,IND,2015_17_TEN_IND,Rob Chudzinski,Greg Manusky
-2015,JAX,2015_01_CAR_JAX,Greg Olson,Bob Babich
-2015,JAX,2015_02_MIA_JAX,Greg Olson,Bob Babich
-2015,JAX,2015_03_JAX_NE,Greg Olson,Bob Babich
-2015,JAX,2015_04_JAX_IND,Greg Olson,Bob Babich
-2015,JAX,2015_05_JAX_TB,Greg Olson,Bob Babich
-2015,JAX,2015_06_HOU_JAX,Greg Olson,Bob Babich
-2015,JAX,2015_07_BUF_JAX,Greg Olson,Bob Babich
-2015,JAX,2015_09_JAX_NYJ,Greg Olson,Bob Babich
-2015,JAX,2015_10_JAX_BAL,Greg Olson,Bob Babich
-2015,JAX,2015_11_TEN_JAX,Greg Olson,Bob Babich
-2015,JAX,2015_12_SD_JAX,Greg Olson,Bob Babich
-2015,JAX,2015_13_JAX_TEN,Greg Olson,Bob Babich
-2015,JAX,2015_14_IND_JAX,Greg Olson,Bob Babich
-2015,JAX,2015_15_ATL_JAX,Greg Olson,Bob Babich
-2015,JAX,2015_16_JAX_NO,Greg Olson,Bob Babich
-2015,JAX,2015_17_JAX_HOU,Greg Olson,Bob Babich
-2015,KC,2015_01_KC_HOU,Andy Reid,Bob Sutton
-2015,KC,2015_02_DEN_KC,Andy Reid,Bob Sutton
-2015,KC,2015_03_KC_GB,Andy Reid,Bob Sutton
-2015,KC,2015_04_KC_CIN,Andy Reid,Bob Sutton
-2015,KC,2015_05_CHI_KC,Andy Reid,Bob Sutton
-2015,KC,2015_06_KC_MIN,Andy Reid,Bob Sutton
-2015,KC,2015_07_PIT_KC,Doug Pederson,Bob Sutton
-2015,KC,2015_08_DET_KC,Doug Pederson,Bob Sutton
-2015,KC,2015_10_KC_DEN,Doug Pederson,Bob Sutton
-2015,KC,2015_11_KC_SD,Doug Pederson,Bob Sutton
-2015,KC,2015_12_BUF_KC,Doug Pederson,Bob Sutton
-2015,KC,2015_13_KC_OAK,Doug Pederson,Bob Sutton
-2015,KC,2015_14_SD_KC,Doug Pederson,Bob Sutton
-2015,KC,2015_15_KC_BAL,Doug Pederson,Bob Sutton
-2015,KC,2015_16_CLE_KC,Doug Pederson,Bob Sutton
-2015,KC,2015_17_OAK_KC,Doug Pederson,Bob Sutton
-2015,KC,2015_18_KC_HOU,Doug Pederson,Bob Sutton
-2015,KC,2015_19_KC_NE,Doug Pederson,Bob Sutton
-2015,LA,2015_01_SEA_STL,Rob Boras,Gregg Williams
-2015,LA,2015_02_STL_WAS,Rob Boras,Gregg Williams
-2015,LA,2015_03_PIT_STL,Rob Boras,Gregg Williams
-2015,LA,2015_04_STL_ARI,Rob Boras,Gregg Williams
-2015,LA,2015_05_STL_GB,Rob Boras,Gregg Williams
-2015,LA,2015_07_CLE_STL,Rob Boras,Gregg Williams
-2015,LA,2015_08_SF_STL,Rob Boras,Gregg Williams
-2015,LA,2015_09_STL_MIN,Rob Boras,Gregg Williams
-2015,LA,2015_10_CHI_STL,Rob Boras,Gregg Williams
-2015,LA,2015_11_STL_BAL,Rob Boras,Gregg Williams
-2015,LA,2015_12_STL_CIN,Rob Boras,Gregg Williams
-2015,LA,2015_13_ARI_STL,Rob Boras,Gregg Williams
-2015,LA,2015_14_DET_STL,Rob Boras,Gregg Williams
-2015,LA,2015_15_TB_STL,Rob Boras,Gregg Williams
-2015,LA,2015_16_STL_SEA,Rob Boras,Gregg Williams
-2015,LA,2015_17_STL_SF,Rob Boras,Gregg Williams
-2015,LAC,2015_01_DET_SD,Frank Reich,John Pagano
-2015,LAC,2015_02_SD_CIN,Frank Reich,John Pagano
-2015,LAC,2015_03_SD_MIN,Frank Reich,John Pagano
-2015,LAC,2015_04_CLE_SD,Frank Reich,John Pagano
-2015,LAC,2015_05_PIT_SD,Frank Reich,John Pagano
-2015,LAC,2015_06_SD_GB,Frank Reich,John Pagano
-2015,LAC,2015_07_OAK_SD,Frank Reich,John Pagano
-2015,LAC,2015_08_SD_BAL,Frank Reich,John Pagano
-2015,LAC,2015_09_CHI_SD,Frank Reich,John Pagano
-2015,LAC,2015_11_KC_SD,Frank Reich,John Pagano
-2015,LAC,2015_12_SD_JAX,Frank Reich,John Pagano
-2015,LAC,2015_13_DEN_SD,Frank Reich,John Pagano
-2015,LAC,2015_14_SD_KC,Frank Reich,John Pagano
-2015,LAC,2015_15_MIA_SD,Frank Reich,John Pagano
-2015,LAC,2015_16_SD_OAK,Frank Reich,John Pagano
-2015,LAC,2015_17_SD_DEN,Frank Reich,John Pagano
-2015,LV,2015_01_CIN_OAK,Greg Olson,Jason Tarver
-2015,LV,2015_02_BAL_OAK,Greg Olson,Jason Tarver
-2015,LV,2015_03_OAK_CLE,Greg Olson,Jason Tarver
-2015,LV,2015_04_OAK_CHI,Greg Olson,Jason Tarver
-2015,LV,2015_05_DEN_OAK,Greg Olson,Jason Tarver
-2015,LV,2015_07_OAK_SD,Greg Olson,Jason Tarver
-2015,LV,2015_08_NYJ_OAK,Greg Olson,Jason Tarver
-2015,LV,2015_09_OAK_PIT,Greg Olson,Jason Tarver
-2015,LV,2015_10_MIN_OAK,Greg Olson,Jason Tarver
-2015,LV,2015_11_OAK_DET,Greg Olson,Jason Tarver
-2015,LV,2015_12_OAK_TEN,Greg Olson,Jason Tarver
-2015,LV,2015_13_KC_OAK,Greg Olson,Jason Tarver
-2015,LV,2015_14_OAK_DEN,Greg Olson,Jason Tarver
-2015,LV,2015_15_GB_OAK,Greg Olson,Jason Tarver
-2015,LV,2015_16_SD_OAK,Greg Olson,Jason Tarver
-2015,LV,2015_17_OAK_KC,Greg Olson,Jason Tarver
-2015,MIA,2015_01_MIA_WAS,Bill Lazor,Kevin Coyle
-2015,MIA,2015_02_MIA_JAX,Bill Lazor,Kevin Coyle
-2015,MIA,2015_03_BUF_MIA,Bill Lazor,Kevin Coyle
-2015,MIA,2015_04_NYJ_MIA,Bill Lazor,Kevin Coyle
-2015,MIA,2015_06_MIA_TEN,Bill Lazor,Lou Anarumo
-2015,MIA,2015_07_HOU_MIA,Bill Lazor,Lou Anarumo
-2015,MIA,2015_08_MIA_NE,Bill Lazor,Lou Anarumo
-2015,MIA,2015_09_MIA_BUF,Bill Lazor,Lou Anarumo
-2015,MIA,2015_10_MIA_PHI,Bill Lazor,Lou Anarumo
-2015,MIA,2015_11_DAL_MIA,Bill Lazor,Lou Anarumo
-2015,MIA,2015_12_MIA_NYJ,Bill Lazor,Lou Anarumo
-2015,MIA,2015_13_BAL_MIA,Zac Taylor,Lou Anarumo
-2015,MIA,2015_14_NYG_MIA,Zac Taylor,Lou Anarumo
-2015,MIA,2015_15_MIA_SD,Zac Taylor,Lou Anarumo
-2015,MIA,2015_16_IND_MIA,Zac Taylor,Lou Anarumo
-2015,MIA,2015_17_NE_MIA,Zac Taylor,Lou Anarumo
-2015,MIN,2015_01_MIN_SF,Norv Turner,Mike Zimmer
-2015,MIN,2015_02_DET_MIN,Norv Turner,Mike Zimmer
-2015,MIN,2015_03_SD_MIN,Norv Turner,Mike Zimmer
-2015,MIN,2015_04_MIN_DEN,Norv Turner,Mike Zimmer
-2015,MIN,2015_06_KC_MIN,Norv Turner,Mike Zimmer
-2015,MIN,2015_07_MIN_DET,Norv Turner,Mike Zimmer
-2015,MIN,2015_08_MIN_CHI,Norv Turner,Mike Zimmer
-2015,MIN,2015_09_STL_MIN,Norv Turner,Mike Zimmer
-2015,MIN,2015_10_MIN_OAK,Norv Turner,Mike Zimmer
-2015,MIN,2015_11_GB_MIN,Norv Turner,Mike Zimmer
-2015,MIN,2015_12_MIN_ATL,Norv Turner,Mike Zimmer
-2015,MIN,2015_13_SEA_MIN,Norv Turner,Mike Zimmer
-2015,MIN,2015_14_MIN_ARI,Norv Turner,Mike Zimmer
-2015,MIN,2015_15_CHI_MIN,Norv Turner,Mike Zimmer
-2015,MIN,2015_16_NYG_MIN,Norv Turner,Mike Zimmer
-2015,MIN,2015_17_MIN_GB,Norv Turner,Mike Zimmer
-2015,MIN,2015_18_SEA_MIN,Norv Turner,Mike Zimmer
-2015,NE,2015_01_PIT_NE,Josh McDaniels,Matt Patricia
-2015,NE,2015_02_NE_BUF,Josh McDaniels,Matt Patricia
-2015,NE,2015_03_JAX_NE,Josh McDaniels,Matt Patricia
-2015,NE,2015_05_NE_DAL,Josh McDaniels,Matt Patricia
-2015,NE,2015_06_NE_IND,Josh McDaniels,Matt Patricia
-2015,NE,2015_07_NYJ_NE,Josh McDaniels,Matt Patricia
-2015,NE,2015_08_MIA_NE,Josh McDaniels,Matt Patricia
-2015,NE,2015_09_WAS_NE,Josh McDaniels,Matt Patricia
-2015,NE,2015_10_NE_NYG,Josh McDaniels,Matt Patricia
-2015,NE,2015_11_BUF_NE,Josh McDaniels,Matt Patricia
-2015,NE,2015_12_NE_DEN,Josh McDaniels,Matt Patricia
-2015,NE,2015_13_PHI_NE,Josh McDaniels,Matt Patricia
-2015,NE,2015_14_NE_HOU,Josh McDaniels,Matt Patricia
-2015,NE,2015_15_TEN_NE,Josh McDaniels,Matt Patricia
-2015,NE,2015_16_NE_NYJ,Josh McDaniels,Matt Patricia
-2015,NE,2015_17_NE_MIA,Josh McDaniels,Matt Patricia
-2015,NE,2015_19_KC_NE,Josh McDaniels,Matt Patricia
-2015,NE,2015_20_NE_DEN,Josh McDaniels,Matt Patricia
-2015,NO,2015_01_NO_ARI,Sean Payton,Rob Ryan
-2015,NO,2015_02_TB_NO,Sean Payton,Rob Ryan
-2015,NO,2015_03_NO_CAR,Sean Payton,Rob Ryan
-2015,NO,2015_04_DAL_NO,Sean Payton,Rob Ryan
-2015,NO,2015_05_NO_PHI,Sean Payton,Rob Ryan
-2015,NO,2015_06_ATL_NO,Sean Payton,Rob Ryan
-2015,NO,2015_07_NO_IND,Sean Payton,Rob Ryan
-2015,NO,2015_08_NYG_NO,Sean Payton,Rob Ryan
-2015,NO,2015_09_TEN_NO,Sean Payton,Rob Ryan
-2015,NO,2015_10_NO_WAS,Sean Payton,Rob Ryan
-2015,NO,2015_12_NO_HOU,Sean Payton,Dennis Allen
-2015,NO,2015_13_CAR_NO,Sean Payton,Dennis Allen
-2015,NO,2015_14_NO_TB,Sean Payton,Dennis Allen
-2015,NO,2015_15_DET_NO,Sean Payton,Dennis Allen
-2015,NO,2015_16_JAX_NO,Sean Payton,Dennis Allen
-2015,NO,2015_17_NO_ATL,Sean Payton,Dennis Allen
-2015,NYG,2015_01_NYG_DAL,Ben McAdoo,Perry Fewell
-2015,NYG,2015_02_ATL_NYG,Ben McAdoo,Steve Spagnuolo
-2015,NYG,2015_03_WAS_NYG,Ben McAdoo,Steve Spagnuolo
-2015,NYG,2015_04_NYG_BUF,Ben McAdoo,Steve Spagnuolo
-2015,NYG,2015_05_SF_NYG,Ben McAdoo,Steve Spagnuolo
-2015,NYG,2015_06_NYG_PHI,Ben McAdoo,Steve Spagnuolo
-2015,NYG,2015_07_DAL_NYG,Ben McAdoo,Steve Spagnuolo
-2015,NYG,2015_08_NYG_NO,Ben McAdoo,Steve Spagnuolo
-2015,NYG,2015_09_NYG_TB,Ben McAdoo,Steve Spagnuolo
-2015,NYG,2015_10_NE_NYG,Ben McAdoo,Steve Spagnuolo
-2015,NYG,2015_12_NYG_WAS,Ben McAdoo,Steve Spagnuolo
-2015,NYG,2015_13_NYJ_NYG,Ben McAdoo,Steve Spagnuolo
-2015,NYG,2015_14_NYG_MIA,Ben McAdoo,Steve Spagnuolo
-2015,NYG,2015_15_CAR_NYG,Ben McAdoo,Steve Spagnuolo
-2015,NYG,2015_16_NYG_MIN,Ben McAdoo,Steve Spagnuolo
-2015,NYG,2015_17_PHI_NYG,Ben McAdoo,Steve Spagnuolo
-2015,NYJ,2015_01_CLE_NYJ,Chan Gailey,Todd Bowles
-2015,NYJ,2015_02_NYJ_IND,Chan Gailey,Todd Bowles
-2015,NYJ,2015_03_PHI_NYJ,Chan Gailey,Todd Bowles
-2015,NYJ,2015_04_NYJ_MIA,Chan Gailey,Todd Bowles
-2015,NYJ,2015_06_WAS_NYJ,Chan Gailey,Todd Bowles
-2015,NYJ,2015_07_NYJ_NE,Chan Gailey,Todd Bowles
-2015,NYJ,2015_08_NYJ_OAK,Chan Gailey,Todd Bowles
-2015,NYJ,2015_09_JAX_NYJ,Chan Gailey,Todd Bowles
-2015,NYJ,2015_10_BUF_NYJ,Chan Gailey,Todd Bowles
-2015,NYJ,2015_11_NYJ_HOU,Chan Gailey,Todd Bowles
-2015,NYJ,2015_12_MIA_NYJ,Chan Gailey,Todd Bowles
-2015,NYJ,2015_13_NYJ_NYG,Chan Gailey,Todd Bowles
-2015,NYJ,2015_14_TEN_NYJ,Chan Gailey,Todd Bowles
-2015,NYJ,2015_15_NYJ_DAL,Chan Gailey,Todd Bowles
-2015,NYJ,2015_16_NE_NYJ,Chan Gailey,Todd Bowles
-2015,NYJ,2015_17_NYJ_BUF,Chan Gailey,Todd Bowles
-2015,PHI,2015_01_PHI_ATL,Chip Kelly,Billy Davis
-2015,PHI,2015_02_DAL_PHI,Chip Kelly,Billy Davis
-2015,PHI,2015_03_PHI_NYJ,Chip Kelly,Billy Davis
-2015,PHI,2015_04_PHI_WAS,Chip Kelly,Billy Davis
-2015,PHI,2015_05_NO_PHI,Chip Kelly,Billy Davis
-2015,PHI,2015_06_NYG_PHI,Chip Kelly,Billy Davis
-2015,PHI,2015_07_PHI_CAR,Chip Kelly,Billy Davis
-2015,PHI,2015_09_PHI_DAL,Chip Kelly,Billy Davis
-2015,PHI,2015_10_MIA_PHI,Chip Kelly,Billy Davis
-2015,PHI,2015_11_TB_PHI,Chip Kelly,Billy Davis
-2015,PHI,2015_12_PHI_DET,Chip Kelly,Billy Davis
-2015,PHI,2015_13_PHI_NE,Chip Kelly,Billy Davis
-2015,PHI,2015_14_BUF_PHI,Chip Kelly,Billy Davis
-2015,PHI,2015_15_ARI_PHI,Chip Kelly,Billy Davis
-2015,PHI,2015_16_WAS_PHI,Chip Kelly,Billy Davis
-2015,PHI,2015_17_PHI_NYG,Pat Shurmur,Billy Davis
-2015,PIT,2015_01_PIT_NE,Todd Haley,Mike Tomlin
-2015,PIT,2015_02_SF_PIT,Todd Haley,Mike Tomlin
-2015,PIT,2015_03_PIT_STL,Todd Haley,Mike Tomlin
-2015,PIT,2015_04_BAL_PIT,Todd Haley,Mike Tomlin
-2015,PIT,2015_05_PIT_SD,Todd Haley,Mike Tomlin
-2015,PIT,2015_06_ARI_PIT,Todd Haley,Mike Tomlin
-2015,PIT,2015_07_PIT_KC,Todd Haley,Mike Tomlin
-2015,PIT,2015_08_CIN_PIT,Todd Haley,Mike Tomlin
-2015,PIT,2015_09_OAK_PIT,Todd Haley,Mike Tomlin
-2015,PIT,2015_10_CLE_PIT,Todd Haley,Mike Tomlin
-2015,PIT,2015_12_PIT_SEA,Todd Haley,Mike Tomlin
-2015,PIT,2015_13_IND_PIT,Todd Haley,Mike Tomlin
-2015,PIT,2015_14_PIT_CIN,Todd Haley,Mike Tomlin
-2015,PIT,2015_15_DEN_PIT,Todd Haley,Mike Tomlin
-2015,PIT,2015_16_PIT_BAL,Todd Haley,Mike Tomlin
-2015,PIT,2015_17_PIT_CLE,Todd Haley,Mike Tomlin
-2015,PIT,2015_18_PIT_CIN,Todd Haley,Mike Tomlin
-2015,PIT,2015_19_PIT_DEN,Todd Haley,Mike Tomlin
-2015,SEA,2015_01_SEA_STL,Darrell Bevell,Kris Richard
-2015,SEA,2015_02_SEA_GB,Darrell Bevell,Kris Richard
-2015,SEA,2015_03_CHI_SEA,Darrell Bevell,Kris Richard
-2015,SEA,2015_04_DET_SEA,Darrell Bevell,Kris Richard
-2015,SEA,2015_05_SEA_CIN,Darrell Bevell,Kris Richard
-2015,SEA,2015_06_CAR_SEA,Darrell Bevell,Kris Richard
-2015,SEA,2015_07_SEA_SF,Darrell Bevell,Kris Richard
-2015,SEA,2015_08_SEA_DAL,Darrell Bevell,Kris Richard
-2015,SEA,2015_10_ARI_SEA,Darrell Bevell,Kris Richard
-2015,SEA,2015_11_SF_SEA,Darrell Bevell,Kris Richard
-2015,SEA,2015_12_PIT_SEA,Darrell Bevell,Kris Richard
-2015,SEA,2015_13_SEA_MIN,Darrell Bevell,Kris Richard
-2015,SEA,2015_14_SEA_BAL,Darrell Bevell,Kris Richard
-2015,SEA,2015_15_CLE_SEA,Darrell Bevell,Kris Richard
-2015,SEA,2015_16_STL_SEA,Darrell Bevell,Kris Richard
-2015,SEA,2015_17_SEA_ARI,Darrell Bevell,Kris Richard
-2015,SEA,2015_18_SEA_MIN,Darrell Bevell,Kris Richard
-2015,SEA,2015_19_SEA_CAR,Darrell Bevell,Kris Richard
-2015,SF,2015_01_MIN_SF,Geep Chryst,Eric Mangini
-2015,SF,2015_02_SF_PIT,Geep Chryst,Eric Mangini
-2015,SF,2015_03_SF_ARI,Geep Chryst,Eric Mangini
-2015,SF,2015_04_GB_SF,Geep Chryst,Eric Mangini
-2015,SF,2015_05_SF_NYG,Geep Chryst,Eric Mangini
-2015,SF,2015_06_BAL_SF,Geep Chryst,Eric Mangini
-2015,SF,2015_07_SEA_SF,Geep Chryst,Eric Mangini
-2015,SF,2015_08_SF_STL,Geep Chryst,Eric Mangini
-2015,SF,2015_09_ATL_SF,Geep Chryst,Eric Mangini
-2015,SF,2015_11_SF_SEA,Geep Chryst,Eric Mangini
-2015,SF,2015_12_ARI_SF,Geep Chryst,Eric Mangini
-2015,SF,2015_13_SF_CHI,Geep Chryst,Eric Mangini
-2015,SF,2015_14_SF_CLE,Geep Chryst,Eric Mangini
-2015,SF,2015_15_CIN_SF,Geep Chryst,Eric Mangini
-2015,SF,2015_16_SF_DET,Geep Chryst,Eric Mangini
-2015,SF,2015_17_STL_SF,Geep Chryst,Eric Mangini
-2015,TB,2015_01_TEN_TB,Dirk Koetter,Leslie Frazier
-2015,TB,2015_02_TB_NO,Dirk Koetter,Leslie Frazier
-2015,TB,2015_03_TB_HOU,Dirk Koetter,Leslie Frazier
-2015,TB,2015_04_CAR_TB,Dirk Koetter,Leslie Frazier
-2015,TB,2015_05_JAX_TB,Dirk Koetter,Leslie Frazier
-2015,TB,2015_07_TB_WAS,Dirk Koetter,Leslie Frazier
-2015,TB,2015_08_TB_ATL,Dirk Koetter,Leslie Frazier
-2015,TB,2015_09_NYG_TB,Dirk Koetter,Leslie Frazier
-2015,TB,2015_10_DAL_TB,Dirk Koetter,Leslie Frazier
-2015,TB,2015_11_TB_PHI,Dirk Koetter,Leslie Frazier
-2015,TB,2015_12_TB_IND,Dirk Koetter,Leslie Frazier
-2015,TB,2015_13_ATL_TB,Dirk Koetter,Leslie Frazier
-2015,TB,2015_14_NO_TB,Dirk Koetter,Leslie Frazier
-2015,TB,2015_15_TB_STL,Dirk Koetter,Leslie Frazier
-2015,TB,2015_16_CHI_TB,Dirk Koetter,Leslie Frazier
-2015,TB,2015_17_TB_CAR,Dirk Koetter,Leslie Frazier
-2015,TEN,2015_01_TEN_TB,Ken Whisenhunt,Ray Horton
-2015,TEN,2015_02_TEN_CLE,Ken Whisenhunt,Ray Horton
-2015,TEN,2015_03_IND_TEN,Ken Whisenhunt,Ray Horton
-2015,TEN,2015_05_BUF_TEN,Ken Whisenhunt,Ray Horton
-2015,TEN,2015_06_MIA_TEN,Ken Whisenhunt,Ray Horton
-2015,TEN,2015_07_ATL_TEN,Ken Whisenhunt,Ray Horton
-2015,TEN,2015_08_TEN_HOU,Ken Whisenhunt,Ray Horton
-2015,TEN,2015_09_TEN_NO,Jason Michael,Ray Horton
-2015,TEN,2015_10_CAR_TEN,Jason Michael,Ray Horton
-2015,TEN,2015_11_TEN_JAX,Jason Michael,Ray Horton
-2015,TEN,2015_12_OAK_TEN,Jason Michael,Ray Horton
-2015,TEN,2015_13_JAX_TEN,Jason Michael,Ray Horton
-2015,TEN,2015_14_TEN_NYJ,Jason Michael,Ray Horton
-2015,TEN,2015_15_TEN_NE,Jason Michael,Ray Horton
-2015,TEN,2015_16_HOU_TEN,Jason Michael,Ray Horton
-2015,TEN,2015_17_TEN_IND,Jason Michael,Ray Horton
-2015,WAS,2015_01_MIA_WAS,Sean McVay,Joe Barry
-2015,WAS,2015_02_STL_WAS,Sean McVay,Joe Barry
-2015,WAS,2015_03_WAS_NYG,Sean McVay,Joe Barry
-2015,WAS,2015_04_PHI_WAS,Sean McVay,Joe Barry
-2015,WAS,2015_05_WAS_ATL,Sean McVay,Joe Barry
-2015,WAS,2015_06_WAS_NYJ,Sean McVay,Joe Barry
-2015,WAS,2015_07_TB_WAS,Sean McVay,Joe Barry
-2015,WAS,2015_09_WAS_NE,Sean McVay,Joe Barry
-2015,WAS,2015_10_NO_WAS,Sean McVay,Joe Barry
-2015,WAS,2015_11_WAS_CAR,Sean McVay,Joe Barry
-2015,WAS,2015_12_NYG_WAS,Sean McVay,Joe Barry
-2015,WAS,2015_13_DAL_WAS,Sean McVay,Joe Barry
-2015,WAS,2015_14_WAS_CHI,Sean McVay,Joe Barry
-2015,WAS,2015_15_BUF_WAS,Sean McVay,Joe Barry
-2015,WAS,2015_16_WAS_PHI,Sean McVay,Joe Barry
-2015,WAS,2015_17_WAS_DAL,Sean McVay,Joe Barry
-2015,WAS,2015_18_GB_WAS,Sean McVay,Joe Barry
 2016,ARI,2016_01_NE_ARI,Bruce Arians,James Bettcher
 2016,ARI,2016_02_TB_ARI,Bruce Arians,James Bettcher
 2016,ARI,2016_03_ARI_BUF,Bruce Arians,James Bettcher
@@ -1733,239 +182,239 @@ season,team,game_id,off_play_caller,def_play_caller
 2023,ARI,2023_16_ARI_CHI,Drew Petzing,Nick Rallis
 2023,ARI,2023_17_ARI_PHI,Drew Petzing,Nick Rallis
 2023,ARI,2023_18_SEA_ARI,Drew Petzing,Nick Rallis
-1999,ATL,1999_01_MIN_ATL,,
-1999,ATL,1999_02_ATL_DAL,,
-1999,ATL,1999_03_ATL_STL,,
-1999,ATL,1999_04_BAL_ATL,,
-1999,ATL,1999_05_ATL_NO,,
-1999,ATL,1999_06_STL_ATL,,
-1999,ATL,1999_07_ATL_PIT,,
-1999,ATL,1999_08_CAR_ATL,,
-1999,ATL,1999_09_JAX_ATL,,
-1999,ATL,1999_11_ATL_TB,,
-1999,ATL,1999_12_ATL_CAR,,
-1999,ATL,1999_13_NO_ATL,,
-1999,ATL,1999_14_ATL_SF,,
-1999,ATL,1999_15_ATL_TEN,,
-1999,ATL,1999_16_ARI_ATL,,
-1999,ATL,1999_17_SF_ATL,,
-2000,ATL,2000_01_SF_ATL,,
-2000,ATL,2000_02_ATL_DEN,,
-2000,ATL,2000_03_ATL_CAR,,
-2000,ATL,2000_04_STL_ATL,,
-2000,ATL,2000_05_ATL_PHI,,
-2000,ATL,2000_06_NYG_ATL,,
-2000,ATL,2000_07_ATL_STL,,
-2000,ATL,2000_08_NO_ATL,,
-2000,ATL,2000_09_CAR_ATL,,
-2000,ATL,2000_10_TB_ATL,,
-2000,ATL,2000_11_ATL_DET,,
-2000,ATL,2000_12_ATL_SF,,
-2000,ATL,2000_13_ATL_OAK,,
-2000,ATL,2000_14_SEA_ATL,,
-2000,ATL,2000_16_ATL_NO,,
-2000,ATL,2000_17_KC_ATL,,
-2001,ATL,2001_01_ATL_SF,,
-2001,ATL,2001_02_CAR_ATL,,
-2001,ATL,2001_03_ATL_ARI,,
-2001,ATL,2001_04_CHI_ATL,,
-2001,ATL,2001_05_SF_ATL,,
-2001,ATL,2001_06_ATL_NO,,
-2001,ATL,2001_08_NE_ATL,,
-2001,ATL,2001_09_DAL_ATL,,
-2001,ATL,2001_10_ATL_GB,,
-2001,ATL,2001_11_ATL_CAR,,
-2001,ATL,2001_12_STL_ATL,,
-2001,ATL,2001_13_NO_ATL,,
-2001,ATL,2001_14_ATL_IND,,
-2001,ATL,2001_15_BUF_ATL,,
-2001,ATL,2001_16_ATL_MIA,,
-2001,ATL,2001_17_ATL_STL,,
-2002,ATL,2002_01_ATL_GB,,
-2002,ATL,2002_02_CHI_ATL,,
-2002,ATL,2002_03_CIN_ATL,,
-2002,ATL,2002_05_TB_ATL,,
-2002,ATL,2002_06_ATL_NYG,,
-2002,ATL,2002_07_CAR_ATL,,
-2002,ATL,2002_08_ATL_NO,,
-2002,ATL,2002_09_BAL_ATL,,
-2002,ATL,2002_10_ATL_PIT,,
-2002,ATL,2002_11_NO_ATL,,
-2002,ATL,2002_12_ATL_CAR,,
-2002,ATL,2002_13_ATL_MIN,,
-2002,ATL,2002_14_ATL_TB,,
-2002,ATL,2002_15_SEA_ATL,,
-2002,ATL,2002_16_DET_ATL,,
-2002,ATL,2002_17_ATL_CLE,,
-2002,ATL,2002_18_ATL_GB,,
-2002,ATL,2002_19_ATL_PHI,,
-2003,ATL,2003_01_ATL_DAL,,
-2003,ATL,2003_02_WAS_ATL,,
-2003,ATL,2003_03_TB_ATL,,
-2003,ATL,2003_04_ATL_CAR,,
-2003,ATL,2003_05_MIN_ATL,,
-2003,ATL,2003_06_ATL_STL,,
-2003,ATL,2003_07_NO_ATL,,
-2003,ATL,2003_09_PHI_ATL,,
-2003,ATL,2003_10_ATL_NYG,,
-2003,ATL,2003_11_ATL_NO,,
-2003,ATL,2003_12_TEN_ATL,,
-2003,ATL,2003_13_ATL_HOU,,
-2003,ATL,2003_14_CAR_ATL,,
-2003,ATL,2003_15_ATL_IND,,
-2003,ATL,2003_16_ATL_TB,,
-2003,ATL,2003_17_JAX_ATL,,
-2004,ATL,2004_01_ATL_SF,,
-2004,ATL,2004_02_STL_ATL,,
-2004,ATL,2004_03_ARI_ATL,,
-2004,ATL,2004_04_ATL_CAR,,
-2004,ATL,2004_05_DET_ATL,,
-2004,ATL,2004_06_SD_ATL,,
-2004,ATL,2004_07_ATL_KC,,
-2004,ATL,2004_08_ATL_DEN,,
-2004,ATL,2004_10_TB_ATL,,
-2004,ATL,2004_11_ATL_NYG,,
-2004,ATL,2004_12_NO_ATL,,
-2004,ATL,2004_13_ATL_TB,,
-2004,ATL,2004_14_OAK_ATL,,
-2004,ATL,2004_15_CAR_ATL,,
-2004,ATL,2004_16_ATL_NO,,
-2004,ATL,2004_17_ATL_SEA,,
-2004,ATL,2004_19_STL_ATL,,
-2004,ATL,2004_20_ATL_PHI,,
-2005,ATL,2005_01_PHI_ATL,,
-2005,ATL,2005_02_ATL_SEA,,
-2005,ATL,2005_03_ATL_BUF,,
-2005,ATL,2005_04_MIN_ATL,,
-2005,ATL,2005_05_NE_ATL,,
-2005,ATL,2005_06_ATL_NO,,
-2005,ATL,2005_07_NYJ_ATL,,
-2005,ATL,2005_09_ATL_MIA,,
-2005,ATL,2005_10_GB_ATL,,
-2005,ATL,2005_11_TB_ATL,,
-2005,ATL,2005_12_ATL_DET,,
-2005,ATL,2005_13_ATL_CAR,,
-2005,ATL,2005_14_NO_ATL,,
-2005,ATL,2005_15_ATL_CHI,,
-2005,ATL,2005_16_ATL_TB,,
-2005,ATL,2005_17_CAR_ATL,,
-2006,ATL,2006_01_ATL_CAR,,
-2006,ATL,2006_02_TB_ATL,,
-2006,ATL,2006_03_ATL_NO,,
-2006,ATL,2006_04_ARI_ATL,,
-2006,ATL,2006_06_NYG_ATL,,
-2006,ATL,2006_07_PIT_ATL,,
-2006,ATL,2006_08_ATL_CIN,,
-2006,ATL,2006_09_ATL_DET,,
-2006,ATL,2006_10_CLE_ATL,,
-2006,ATL,2006_11_ATL_BAL,,
-2006,ATL,2006_12_NO_ATL,,
-2006,ATL,2006_13_ATL_WAS,,
-2006,ATL,2006_14_ATL_TB,,
-2006,ATL,2006_15_DAL_ATL,,
-2006,ATL,2006_16_CAR_ATL,,
-2006,ATL,2006_17_ATL_PHI,,
-2007,ATL,2007_01_ATL_MIN,,
-2007,ATL,2007_02_ATL_JAX,,
-2007,ATL,2007_03_CAR_ATL,,
-2007,ATL,2007_04_HOU_ATL,,
-2007,ATL,2007_05_ATL_TEN,,
-2007,ATL,2007_06_NYG_ATL,,
-2007,ATL,2007_07_ATL_NO,,
-2007,ATL,2007_09_SF_ATL,,
-2007,ATL,2007_10_ATL_CAR,,
-2007,ATL,2007_11_TB_ATL,,
-2007,ATL,2007_12_IND_ATL,,
-2007,ATL,2007_13_ATL_STL,,
-2007,ATL,2007_14_NO_ATL,,
-2007,ATL,2007_15_ATL_TB,,
-2007,ATL,2007_16_ATL_ARI,,
-2007,ATL,2007_17_SEA_ATL,,
-2008,ATL,2008_01_DET_ATL,,
-2008,ATL,2008_02_ATL_TB,,
-2008,ATL,2008_03_KC_ATL,,
-2008,ATL,2008_04_ATL_CAR,,
-2008,ATL,2008_05_ATL_GB,,
-2008,ATL,2008_06_CHI_ATL,,
-2008,ATL,2008_08_ATL_PHI,,
-2008,ATL,2008_09_ATL_OAK,,
-2008,ATL,2008_10_NO_ATL,,
-2008,ATL,2008_11_DEN_ATL,,
-2008,ATL,2008_12_CAR_ATL,,
-2008,ATL,2008_13_ATL_SD,,
-2008,ATL,2008_14_ATL_NO,,
-2008,ATL,2008_15_TB_ATL,,
-2008,ATL,2008_16_ATL_MIN,,
-2008,ATL,2008_17_STL_ATL,,
-2008,ATL,2008_18_ATL_ARI,,
-2009,ATL,2009_01_MIA_ATL,,
-2009,ATL,2009_02_CAR_ATL,,
-2009,ATL,2009_03_ATL_NE,,
-2009,ATL,2009_05_ATL_SF,,
-2009,ATL,2009_06_CHI_ATL,,
-2009,ATL,2009_07_ATL_DAL,,
-2009,ATL,2009_08_ATL_NO,,
-2009,ATL,2009_09_WAS_ATL,,
-2009,ATL,2009_10_ATL_CAR,,
-2009,ATL,2009_11_ATL_NYG,,
-2009,ATL,2009_12_TB_ATL,,
-2009,ATL,2009_13_PHI_ATL,,
-2009,ATL,2009_14_NO_ATL,,
-2009,ATL,2009_15_ATL_NYJ,,
-2009,ATL,2009_16_BUF_ATL,,
-2009,ATL,2009_17_ATL_TB,,
-2010,ATL,2010_01_ATL_PIT,,
-2010,ATL,2010_02_ARI_ATL,,
-2010,ATL,2010_03_ATL_NO,,
-2010,ATL,2010_04_SF_ATL,,
-2010,ATL,2010_05_ATL_CLE,,
-2010,ATL,2010_06_ATL_PHI,,
-2010,ATL,2010_07_CIN_ATL,,
-2010,ATL,2010_09_TB_ATL,,
-2010,ATL,2010_10_BAL_ATL,,
-2010,ATL,2010_11_ATL_STL,,
-2010,ATL,2010_12_GB_ATL,,
-2010,ATL,2010_13_ATL_TB,,
-2010,ATL,2010_14_ATL_CAR,,
-2010,ATL,2010_15_ATL_SEA,,
-2010,ATL,2010_16_NO_ATL,,
-2010,ATL,2010_17_CAR_ATL,,
-2010,ATL,2010_19_GB_ATL,,
-2011,ATL,2011_01_ATL_CHI,,
-2011,ATL,2011_02_PHI_ATL,,
-2011,ATL,2011_03_ATL_TB,,
-2011,ATL,2011_04_ATL_SEA,,
-2011,ATL,2011_05_GB_ATL,,
-2011,ATL,2011_06_CAR_ATL,,
-2011,ATL,2011_07_ATL_DET,,
-2011,ATL,2011_09_ATL_IND,,
-2011,ATL,2011_10_NO_ATL,,
-2011,ATL,2011_11_TEN_ATL,,
-2011,ATL,2011_12_MIN_ATL,,
-2011,ATL,2011_13_ATL_HOU,,
-2011,ATL,2011_14_ATL_CAR,,
-2011,ATL,2011_15_JAX_ATL,,
-2011,ATL,2011_16_ATL_NO,,
-2011,ATL,2011_17_TB_ATL,,
-2011,ATL,2011_18_ATL_NYG,,
-2012,ATL,2012_01_ATL_KC,,
-2012,ATL,2012_02_DEN_ATL,,
-2012,ATL,2012_03_ATL_SD,,
-2012,ATL,2012_04_CAR_ATL,,
-2012,ATL,2012_05_ATL_WAS,,
-2012,ATL,2012_06_OAK_ATL,,
-2012,ATL,2012_08_ATL_PHI,,
-2012,ATL,2012_09_DAL_ATL,,
-2012,ATL,2012_10_ATL_NO,,
-2012,ATL,2012_11_ARI_ATL,,
-2012,ATL,2012_12_ATL_TB,,
-2012,ATL,2012_13_NO_ATL,,
-2012,ATL,2012_14_ATL_CAR,,
-2012,ATL,2012_15_NYG_ATL,,
-2012,ATL,2012_16_ATL_DET,,
-2012,ATL,2012_17_TB_ATL,,
-2012,ATL,2012_19_SEA_ATL,,
-2012,ATL,2012_20_SF_ATL,,
+1999,ATL,1999_01_MIN_ATL,George Sefcik,Rich Brooks
+1999,ATL,1999_02_ATL_DAL,George Sefcik,Rich Brooks
+1999,ATL,1999_03_ATL_STL,George Sefcik,Rich Brooks
+1999,ATL,1999_04_BAL_ATL,George Sefcik,Rich Brooks
+1999,ATL,1999_05_ATL_NO,George Sefcik,Rich Brooks
+1999,ATL,1999_06_STL_ATL,George Sefcik,Rich Brooks
+1999,ATL,1999_07_ATL_PIT,George Sefcik,Rich Brooks
+1999,ATL,1999_08_CAR_ATL,George Sefcik,Rich Brooks
+1999,ATL,1999_09_JAX_ATL,George Sefcik,Rich Brooks
+1999,ATL,1999_11_ATL_TB,George Sefcik,Rich Brooks
+1999,ATL,1999_12_ATL_CAR,George Sefcik,Rich Brooks
+1999,ATL,1999_13_NO_ATL,George Sefcik,Rich Brooks
+1999,ATL,1999_14_ATL_SF,George Sefcik,Rich Brooks
+1999,ATL,1999_15_ATL_TEN,George Sefcik,Rich Brooks
+1999,ATL,1999_16_ARI_ATL,George Sefcik,Rich Brooks
+1999,ATL,1999_17_SF_ATL,George Sefcik,Rich Brooks
+2000,ATL,2000_01_SF_ATL,George Sefcik,Rich Brooks
+2000,ATL,2000_02_ATL_DEN,George Sefcik,Rich Brooks
+2000,ATL,2000_03_ATL_CAR,George Sefcik,Rich Brooks
+2000,ATL,2000_04_STL_ATL,George Sefcik,Rich Brooks
+2000,ATL,2000_05_ATL_PHI,George Sefcik,Rich Brooks
+2000,ATL,2000_06_NYG_ATL,George Sefcik,Rich Brooks
+2000,ATL,2000_07_ATL_STL,George Sefcik,Rich Brooks
+2000,ATL,2000_08_NO_ATL,George Sefcik,Rich Brooks
+2000,ATL,2000_09_CAR_ATL,George Sefcik,Rich Brooks
+2000,ATL,2000_10_TB_ATL,George Sefcik,Rich Brooks
+2000,ATL,2000_11_ATL_DET,George Sefcik,Rich Brooks
+2000,ATL,2000_12_ATL_SF,George Sefcik,Rich Brooks
+2000,ATL,2000_13_ATL_OAK,George Sefcik,Rich Brooks
+2000,ATL,2000_14_SEA_ATL,George Sefcik,Rich Brooks
+2000,ATL,2000_16_ATL_NO,George Sefcik,Rich Brooks
+2000,ATL,2000_17_KC_ATL,George Sefcik,Rich Brooks
+2001,ATL,2001_01_ATL_SF,George Sefcik,Rich Brooks
+2001,ATL,2001_02_CAR_ATL,George Sefcik,Rich Brooks
+2001,ATL,2001_03_ATL_ARI,George Sefcik,Rich Brooks
+2001,ATL,2001_04_CHI_ATL,George Sefcik,Rich Brooks
+2001,ATL,2001_05_SF_ATL,George Sefcik,Rich Brooks
+2001,ATL,2001_06_ATL_NO,George Sefcik,Rich Brooks
+2001,ATL,2001_08_NE_ATL,George Sefcik,Rich Brooks
+2001,ATL,2001_09_DAL_ATL,George Sefcik,Rich Brooks
+2001,ATL,2001_10_ATL_GB,George Sefcik,Rich Brooks
+2001,ATL,2001_11_ATL_CAR,George Sefcik,Rich Brooks
+2001,ATL,2001_12_STL_ATL,George Sefcik,Rich Brooks
+2001,ATL,2001_13_NO_ATL,George Sefcik,Rich Brooks
+2001,ATL,2001_14_ATL_IND,George Sefcik,Rich Brooks
+2001,ATL,2001_15_BUF_ATL,George Sefcik,Rich Brooks
+2001,ATL,2001_16_ATL_MIA,George Sefcik,Rich Brooks
+2001,ATL,2001_17_ATL_STL,George Sefcik,Rich Brooks
+2002,ATL,2002_01_ATL_GB,George Sefcik,Wade Phillips
+2002,ATL,2002_02_CHI_ATL,George Sefcik,Wade Phillips
+2002,ATL,2002_03_CIN_ATL,George Sefcik,Wade Phillips
+2002,ATL,2002_05_TB_ATL,George Sefcik,Wade Phillips
+2002,ATL,2002_06_ATL_NYG,George Sefcik,Wade Phillips
+2002,ATL,2002_07_CAR_ATL,George Sefcik,Wade Phillips
+2002,ATL,2002_08_ATL_NO,George Sefcik,Wade Phillips
+2002,ATL,2002_09_BAL_ATL,George Sefcik,Wade Phillips
+2002,ATL,2002_10_ATL_PIT,George Sefcik,Wade Phillips
+2002,ATL,2002_11_NO_ATL,George Sefcik,Wade Phillips
+2002,ATL,2002_12_ATL_CAR,George Sefcik,Wade Phillips
+2002,ATL,2002_13_ATL_MIN,George Sefcik,Wade Phillips
+2002,ATL,2002_14_ATL_TB,George Sefcik,Wade Phillips
+2002,ATL,2002_15_SEA_ATL,George Sefcik,Wade Phillips
+2002,ATL,2002_16_DET_ATL,George Sefcik,Wade Phillips
+2002,ATL,2002_17_ATL_CLE,George Sefcik,Wade Phillips
+2002,ATL,2002_18_ATL_GB,George Sefcik,Wade Phillips
+2002,ATL,2002_19_ATL_PHI,George Sefcik,Wade Phillips
+2003,ATL,2003_01_ATL_DAL,Pete Mangurian,Wade Phillips
+2003,ATL,2003_02_WAS_ATL,Pete Mangurian,Wade Phillips
+2003,ATL,2003_03_TB_ATL,Pete Mangurian,Wade Phillips
+2003,ATL,2003_04_ATL_CAR,Pete Mangurian,Wade Phillips
+2003,ATL,2003_05_MIN_ATL,Pete Mangurian,Wade Phillips
+2003,ATL,2003_06_ATL_STL,Pete Mangurian,Wade Phillips
+2003,ATL,2003_07_NO_ATL,Pete Mangurian,Wade Phillips
+2003,ATL,2003_09_PHI_ATL,Pete Mangurian,Wade Phillips
+2003,ATL,2003_10_ATL_NYG,Pete Mangurian,Wade Phillips
+2003,ATL,2003_11_ATL_NO,Pete Mangurian,Wade Phillips
+2003,ATL,2003_12_TEN_ATL,Pete Mangurian,Wade Phillips
+2003,ATL,2003_13_ATL_HOU,Pete Mangurian,Wade Phillips
+2003,ATL,2003_14_CAR_ATL,Pete Mangurian,Wade Phillips
+2003,ATL,2003_15_ATL_IND,Pete Mangurian,Wade Phillips
+2003,ATL,2003_16_ATL_TB,Pete Mangurian,Wade Phillips
+2003,ATL,2003_17_JAX_ATL,Pete Mangurian,Wade Phillips
+2004,ATL,2004_01_ATL_SF,Greg Knapp,Ed Donatell
+2004,ATL,2004_02_STL_ATL,Greg Knapp,Ed Donatell
+2004,ATL,2004_03_ARI_ATL,Greg Knapp,Ed Donatell
+2004,ATL,2004_04_ATL_CAR,Greg Knapp,Ed Donatell
+2004,ATL,2004_05_DET_ATL,Greg Knapp,Ed Donatell
+2004,ATL,2004_06_SD_ATL,Greg Knapp,Ed Donatell
+2004,ATL,2004_07_ATL_KC,Greg Knapp,Ed Donatell
+2004,ATL,2004_08_ATL_DEN,Greg Knapp,Ed Donatell
+2004,ATL,2004_10_TB_ATL,Greg Knapp,Ed Donatell
+2004,ATL,2004_11_ATL_NYG,Greg Knapp,Ed Donatell
+2004,ATL,2004_12_NO_ATL,Greg Knapp,Ed Donatell
+2004,ATL,2004_13_ATL_TB,Greg Knapp,Ed Donatell
+2004,ATL,2004_14_OAK_ATL,Greg Knapp,Ed Donatell
+2004,ATL,2004_15_CAR_ATL,Greg Knapp,Ed Donatell
+2004,ATL,2004_16_ATL_NO,Greg Knapp,Ed Donatell
+2004,ATL,2004_17_ATL_SEA,Greg Knapp,Ed Donatell
+2004,ATL,2004_19_STL_ATL,Greg Knapp,Ed Donatell
+2004,ATL,2004_20_ATL_PHI,Greg Knapp,Ed Donatell
+2005,ATL,2005_01_PHI_ATL,Greg Knapp,Ed Donatell
+2005,ATL,2005_02_ATL_SEA,Greg Knapp,Ed Donatell
+2005,ATL,2005_03_ATL_BUF,Greg Knapp,Ed Donatell
+2005,ATL,2005_04_MIN_ATL,Greg Knapp,Ed Donatell
+2005,ATL,2005_05_NE_ATL,Greg Knapp,Ed Donatell
+2005,ATL,2005_06_ATL_NO,Greg Knapp,Ed Donatell
+2005,ATL,2005_07_NYJ_ATL,Greg Knapp,Ed Donatell
+2005,ATL,2005_09_ATL_MIA,Greg Knapp,Ed Donatell
+2005,ATL,2005_10_GB_ATL,Greg Knapp,Ed Donatell
+2005,ATL,2005_11_TB_ATL,Greg Knapp,Ed Donatell
+2005,ATL,2005_12_ATL_DET,Greg Knapp,Ed Donatell
+2005,ATL,2005_13_ATL_CAR,Greg Knapp,Ed Donatell
+2005,ATL,2005_14_NO_ATL,Greg Knapp,Ed Donatell
+2005,ATL,2005_15_ATL_CHI,Greg Knapp,Ed Donatell
+2005,ATL,2005_16_ATL_TB,Greg Knapp,Ed Donatell
+2005,ATL,2005_17_CAR_ATL,Greg Knapp,Ed Donatell
+2006,ATL,2006_01_ATL_CAR,Greg Knapp,Ed Donatell
+2006,ATL,2006_02_TB_ATL,Greg Knapp,Ed Donatell
+2006,ATL,2006_03_ATL_NO,Greg Knapp,Ed Donatell
+2006,ATL,2006_04_ARI_ATL,Greg Knapp,Ed Donatell
+2006,ATL,2006_06_NYG_ATL,Greg Knapp,Ed Donatell
+2006,ATL,2006_07_PIT_ATL,Greg Knapp,Ed Donatell
+2006,ATL,2006_08_ATL_CIN,Greg Knapp,Ed Donatell
+2006,ATL,2006_09_ATL_DET,Greg Knapp,Ed Donatell
+2006,ATL,2006_10_CLE_ATL,Greg Knapp,Ed Donatell
+2006,ATL,2006_11_ATL_BAL,Greg Knapp,Ed Donatell
+2006,ATL,2006_12_NO_ATL,Greg Knapp,Ed Donatell
+2006,ATL,2006_13_ATL_WAS,Greg Knapp,Ed Donatell
+2006,ATL,2006_14_ATL_TB,Greg Knapp,Ed Donatell
+2006,ATL,2006_15_DAL_ATL,Greg Knapp,Ed Donatell
+2006,ATL,2006_16_CAR_ATL,Greg Knapp,Ed Donatell
+2006,ATL,2006_17_ATL_PHI,Greg Knapp,Ed Donatell
+2007,ATL,2007_01_ATL_MIN,Bobby Petrino,Mike Zimmer
+2007,ATL,2007_02_ATL_JAX,Bobby Petrino,Mike Zimmer
+2007,ATL,2007_03_CAR_ATL,Bobby Petrino,Mike Zimmer
+2007,ATL,2007_04_HOU_ATL,Bobby Petrino,Mike Zimmer
+2007,ATL,2007_05_ATL_TEN,Bobby Petrino,Mike Zimmer
+2007,ATL,2007_06_NYG_ATL,Bobby Petrino,Mike Zimmer
+2007,ATL,2007_07_ATL_NO,Bobby Petrino,Mike Zimmer
+2007,ATL,2007_09_SF_ATL,Bobby Petrino,Mike Zimmer
+2007,ATL,2007_10_ATL_CAR,Bobby Petrino,Mike Zimmer
+2007,ATL,2007_11_TB_ATL,Bobby Petrino,Mike Zimmer
+2007,ATL,2007_12_IND_ATL,Bobby Petrino,Mike Zimmer
+2007,ATL,2007_13_ATL_STL,Bobby Petrino,Mike Zimmer
+2007,ATL,2007_14_NO_ATL,Bobby Petrino,Mike Zimmer
+2007,ATL,2007_15_ATL_TB,Hue Jackson,Mike Zimmer
+2007,ATL,2007_16_ATL_ARI,Hue Jackson,Mike Zimmer
+2007,ATL,2007_17_SEA_ATL,Hue Jackson,Mike Zimmer
+2008,ATL,2008_01_DET_ATL,Mike Mularkey,Brian VanGorder
+2008,ATL,2008_02_ATL_TB,Mike Mularkey,Brian VanGorder
+2008,ATL,2008_03_KC_ATL,Mike Mularkey,Brian VanGorder
+2008,ATL,2008_04_ATL_CAR,Mike Mularkey,Brian VanGorder
+2008,ATL,2008_05_ATL_GB,Mike Mularkey,Brian VanGorder
+2008,ATL,2008_06_CHI_ATL,Mike Mularkey,Brian VanGorder
+2008,ATL,2008_08_ATL_PHI,Mike Mularkey,Brian VanGorder
+2008,ATL,2008_09_ATL_OAK,Mike Mularkey,Brian VanGorder
+2008,ATL,2008_10_NO_ATL,Mike Mularkey,Brian VanGorder
+2008,ATL,2008_11_DEN_ATL,Mike Mularkey,Brian VanGorder
+2008,ATL,2008_12_CAR_ATL,Mike Mularkey,Brian VanGorder
+2008,ATL,2008_13_ATL_SD,Mike Mularkey,Brian VanGorder
+2008,ATL,2008_14_ATL_NO,Mike Mularkey,Brian VanGorder
+2008,ATL,2008_15_TB_ATL,Mike Mularkey,Brian VanGorder
+2008,ATL,2008_16_ATL_MIN,Mike Mularkey,Brian VanGorder
+2008,ATL,2008_17_STL_ATL,Mike Mularkey,Brian VanGorder
+2008,ATL,2008_18_ATL_ARI,Mike Mularkey,Brian VanGorder
+2009,ATL,2009_01_MIA_ATL,Mike Mularkey,Brian VanGorder
+2009,ATL,2009_02_CAR_ATL,Mike Mularkey,Brian VanGorder
+2009,ATL,2009_03_ATL_NE,Mike Mularkey,Brian VanGorder
+2009,ATL,2009_05_ATL_SF,Mike Mularkey,Brian VanGorder
+2009,ATL,2009_06_CHI_ATL,Mike Mularkey,Brian VanGorder
+2009,ATL,2009_07_ATL_DAL,Mike Mularkey,Brian VanGorder
+2009,ATL,2009_08_ATL_NO,Mike Mularkey,Brian VanGorder
+2009,ATL,2009_09_WAS_ATL,Mike Mularkey,Brian VanGorder
+2009,ATL,2009_10_ATL_CAR,Mike Mularkey,Brian VanGorder
+2009,ATL,2009_11_ATL_NYG,Mike Mularkey,Brian VanGorder
+2009,ATL,2009_12_TB_ATL,Mike Mularkey,Brian VanGorder
+2009,ATL,2009_13_PHI_ATL,Mike Mularkey,Brian VanGorder
+2009,ATL,2009_14_NO_ATL,Mike Mularkey,Brian VanGorder
+2009,ATL,2009_15_ATL_NYJ,Mike Mularkey,Brian VanGorder
+2009,ATL,2009_16_BUF_ATL,Mike Mularkey,Brian VanGorder
+2009,ATL,2009_17_ATL_TB,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_01_ATL_PIT,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_02_ARI_ATL,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_03_ATL_NO,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_04_SF_ATL,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_05_ATL_CLE,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_06_ATL_PHI,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_07_CIN_ATL,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_09_TB_ATL,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_10_BAL_ATL,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_11_ATL_STL,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_12_GB_ATL,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_13_ATL_TB,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_14_ATL_CAR,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_15_ATL_SEA,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_16_NO_ATL,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_17_CAR_ATL,Mike Mularkey,Brian VanGorder
+2010,ATL,2010_19_GB_ATL,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_01_ATL_CHI,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_02_PHI_ATL,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_03_ATL_TB,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_04_ATL_SEA,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_05_GB_ATL,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_06_CAR_ATL,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_07_ATL_DET,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_09_ATL_IND,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_10_NO_ATL,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_11_TEN_ATL,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_12_MIN_ATL,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_13_ATL_HOU,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_14_ATL_CAR,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_15_JAX_ATL,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_16_ATL_NO,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_17_TB_ATL,Mike Mularkey,Brian VanGorder
+2011,ATL,2011_18_ATL_NYG,Mike Mularkey,Brian VanGorder
+2012,ATL,2012_01_ATL_KC,Dirk Koetter,Mike Nolan
+2012,ATL,2012_02_DEN_ATL,Dirk Koetter,Mike Nolan
+2012,ATL,2012_03_ATL_SD,Dirk Koetter,Mike Nolan
+2012,ATL,2012_04_CAR_ATL,Dirk Koetter,Mike Nolan
+2012,ATL,2012_05_ATL_WAS,Dirk Koetter,Mike Nolan
+2012,ATL,2012_06_OAK_ATL,Dirk Koetter,Mike Nolan
+2012,ATL,2012_08_ATL_PHI,Dirk Koetter,Mike Nolan
+2012,ATL,2012_09_DAL_ATL,Dirk Koetter,Mike Nolan
+2012,ATL,2012_10_ATL_NO,Dirk Koetter,Mike Nolan
+2012,ATL,2012_11_ARI_ATL,Dirk Koetter,Mike Nolan
+2012,ATL,2012_12_ATL_TB,Dirk Koetter,Mike Nolan
+2012,ATL,2012_13_NO_ATL,Dirk Koetter,Mike Nolan
+2012,ATL,2012_14_ATL_CAR,Dirk Koetter,Mike Nolan
+2012,ATL,2012_15_NYG_ATL,Dirk Koetter,Mike Nolan
+2012,ATL,2012_16_ATL_DET,Dirk Koetter,Mike Nolan
+2012,ATL,2012_17_TB_ATL,Dirk Koetter,Mike Nolan
+2012,ATL,2012_19_SEA_ATL,Dirk Koetter,Mike Nolan
+2012,ATL,2012_20_SF_ATL,Dirk Koetter,Mike Nolan
 2013,ATL,2013_01_ATL_NO,Dirk Koetter,Mike Nolan
 2013,ATL,2013_02_STL_ATL,Dirk Koetter,Mike Nolan
 2013,ATL,2013_03_ATL_MIA,Dirk Koetter,Mike Nolan
@@ -3400,17 +1849,17 @@ season,team,game_id,off_play_caller,def_play_caller
 2023,CAR,2023_04_MIN_CAR,Frank Reich,Eiro Evero
 2023,CAR,2023_05_CAR_DET,Frank Reich,Eiro Evero
 2023,CAR,2023_06_CAR_MIA,Frank Reich,Eiro Evero
-2023,CAR,2023_08_HOU_CAR,Frank Reich,Eiro Evero
-2023,CAR,2023_09_IND_CAR,Frank Reich,Eiro Evero
-2023,CAR,2023_10_CAR_CHI,Frank Reich,Eiro Evero
-2023,CAR,2023_11_DAL_CAR,Frank Reich,Eiro Evero
-2023,CAR,2023_12_CAR_TEN,Frank Reich,Eiro Evero
-2023,CAR,2023_13_CAR_TB,Frank Reich,Eiro Evero
-2023,CAR,2023_14_CAR_NO,Frank Reich,Eiro Evero
-2023,CAR,2023_15_ATL_CAR,Frank Reich,Eiro Evero
-2023,CAR,2023_16_GB_CAR,Frank Reich,Eiro Evero
-2023,CAR,2023_17_CAR_JAX,Frank Reich,Eiro Evero
-2023,CAR,2023_18_TB_CAR,Frank Reich,Eiro Evero
+2023,CAR,2023_08_HOU_CAR,Thomas Brown,Eiro Evero
+2023,CAR,2023_09_IND_CAR,Thomas Brown,Eiro Evero
+2023,CAR,2023_10_CAR_CHI,Thomas Brown,Eiro Evero
+2023,CAR,2023_11_DAL_CAR,Thomas Brown,Eiro Evero
+2023,CAR,2023_12_CAR_TEN,Thomas Brown,Eiro Evero
+2023,CAR,2023_13_CAR_TB,Thomas Brown,Eiro Evero
+2023,CAR,2023_14_CAR_NO,Thomas Brown,Eiro Evero
+2023,CAR,2023_15_ATL_CAR,Thomas Brown,Eiro Evero
+2023,CAR,2023_16_GB_CAR,Thomas Brown,Eiro Evero
+2023,CAR,2023_17_CAR_JAX,Thomas Brown,Eiro Evero
+2023,CAR,2023_18_TB_CAR,Thomas Brown,Eiro Evero
 1999,CHI,1999_01_KC_CHI,,
 1999,CHI,1999_02_SEA_CHI,,
 1999,CHI,1999_03_CHI_OAK,,
@@ -3790,7 +2239,9 @@ season,team,game_id,off_play_caller,def_play_caller
 2021,CHI,2021_17_NYG_CHI,Bill Lazor,Sean Desai
 2021,CHI,2021_18_CHI_MIN,Bill Lazor,Sean Desai
 2022,CHI,2022_01_SF_CHI,Ben McAdoo,Al Holcomb
+2022,CHI,2022_01_SF_CHI,Luke Getsy,Alan Williams
 2022,CHI,2022_02_CHI_GB,Ben McAdoo,Al Holcomb
+2022,CHI,2022_02_CHI_GB,Luke Getsy,Alan Williams
 2022,CHI,2022_03_HOU_CHI,Luke Getsy,Alan Williams
 2022,CHI,2022_04_CHI_NYG,Luke Getsy,Alan Williams
 2022,CHI,2022_05_CHI_MIN,Luke Getsy,Alan Williams
@@ -7916,555 +6367,6 @@ season,team,game_id,off_play_caller,def_play_caller
 2021,KC,2021_19_PIT_KC,Andy Reid,Steve Spagnuolo
 2021,KC,2021_20_BUF_KC,Andy Reid,Steve Spagnuolo
 2021,KC,2021_21_CIN_KC,Andy Reid,Steve Spagnuolo
-2021,LA,2021_01_CHI_LA,Sean McVay,Raheem Morris
-2021,LA,2021_02_LA_IND,Sean McVay,Raheem Morris
-2021,LA,2021_03_TB_LA,Sean McVay,Raheem Morris
-2021,LA,2021_04_ARI_LA,Sean McVay,Raheem Morris
-2021,LA,2021_05_LA_SEA,Sean McVay,Raheem Morris
-2021,LA,2021_06_LA_NYG,Sean McVay,Raheem Morris
-2021,LA,2021_07_DET_LA,Sean McVay,Raheem Morris
-2021,LA,2021_08_LA_HOU,Sean McVay,Raheem Morris
-2021,LA,2021_09_TEN_LA,Sean McVay,Raheem Morris
-2021,LA,2021_10_LA_SF,Sean McVay,Raheem Morris
-2021,LA,2021_12_LA_GB,Sean McVay,Raheem Morris
-2021,LA,2021_13_JAX_LA,Sean McVay,Raheem Morris
-2021,LA,2021_14_LA_ARI,Sean McVay,Raheem Morris
-2021,LA,2021_15_SEA_LA,Sean McVay,Raheem Morris
-2021,LA,2021_16_LA_MIN,Sean McVay,Raheem Morris
-2021,LA,2021_17_LA_BAL,Sean McVay,Raheem Morris
-2021,LA,2021_18_SF_LA,Sean McVay,Raheem Morris
-2021,LA,2021_19_ARI_LA,Sean McVay,Raheem Morris
-2021,LA,2021_20_LA_TB,Sean McVay,Raheem Morris
-2021,LA,2021_21_SF_LA,Sean McVay,Raheem Morris
-2021,LA,2021_22_LA_CIN,Sean McVay,Raheem Morris
-2021,LAC,2021_01_LAC_WAS,Joe Lombardi,Brandon Staley
-2021,LAC,2021_02_DAL_LAC,Joe Lombardi,Brandon Staley
-2021,LAC,2021_03_LAC_KC,Joe Lombardi,Brandon Staley
-2021,LAC,2021_04_LV_LAC,Joe Lombardi,Brandon Staley
-2021,LAC,2021_05_CLE_LAC,Joe Lombardi,Brandon Staley
-2021,LAC,2021_06_LAC_BAL,Joe Lombardi,Brandon Staley
-2021,LAC,2021_08_NE_LAC,Joe Lombardi,Brandon Staley
-2021,LAC,2021_09_LAC_PHI,Joe Lombardi,Brandon Staley
-2021,LAC,2021_10_MIN_LAC,Joe Lombardi,Brandon Staley
-2021,LAC,2021_11_PIT_LAC,Joe Lombardi,Brandon Staley
-2021,LAC,2021_12_LAC_DEN,Joe Lombardi,Brandon Staley
-2021,LAC,2021_13_LAC_CIN,Joe Lombardi,Brandon Staley
-2021,LAC,2021_14_NYG_LAC,Joe Lombardi,Brandon Staley
-2021,LAC,2021_15_KC_LAC,Joe Lombardi,Brandon Staley
-2021,LAC,2021_16_LAC_HOU,Joe Lombardi,Brandon Staley
-2021,LAC,2021_17_DEN_LAC,Joe Lombardi,Brandon Staley
-2021,LAC,2021_18_LAC_LV,Joe Lombardi,Brandon Staley
-2021,LV,2021_01_BAL_LV,Jon Gruden,Gus Bradley
-2021,LV,2021_02_LV_PIT,Jon Gruden,Gus Bradley
-2021,LV,2021_03_MIA_LV,Jon Gruden,Gus Bradley
-2021,LV,2021_04_LV_LAC,Jon Gruden,Gus Bradley
-2021,LV,2021_05_CHI_LV,Jon Gruden,Gus Bradley
-2021,LV,2021_06_LV_DEN,Greg Olson,Gus Bradley
-2021,LV,2021_07_PHI_LV,Greg Olson,Gus Bradley
-2021,LV,2021_09_LV_NYG,Greg Olson,Gus Bradley
-2021,LV,2021_10_KC_LV,Greg Olson,Gus Bradley
-2021,LV,2021_11_CIN_LV,Greg Olson,Gus Bradley
-2021,LV,2021_12_LV_DAL,Greg Olson,Gus Bradley
-2021,LV,2021_13_WAS_LV,Greg Olson,Gus Bradley
-2021,LV,2021_14_LV_KC,Greg Olson,Gus Bradley
-2021,LV,2021_15_LV_CLE,Greg Olson,Gus Bradley
-2021,LV,2021_16_DEN_LV,Greg Olson,Gus Bradley
-2021,LV,2021_17_LV_IND,Greg Olson,Gus Bradley
-2021,LV,2021_18_LAC_LV,Greg Olson,Gus Bradley
-2021,LV,2021_19_LV_CIN,Greg Olson,Gus Bradley
-2021,MIA,2021_01_MIA_NE,George Godsey,Josh Boyer
-2021,MIA,2021_02_BUF_MIA,George Godsey,Josh Boyer
-2021,MIA,2021_03_MIA_LV,George Godsey,Josh Boyer
-2021,MIA,2021_04_IND_MIA,George Godsey,Josh Boyer
-2021,MIA,2021_05_MIA_TB,George Godsey,Josh Boyer
-2021,MIA,2021_06_MIA_JAX,George Godsey,Josh Boyer
-2021,MIA,2021_07_ATL_MIA,George Godsey,Josh Boyer
-2021,MIA,2021_08_MIA_BUF,George Godsey,Josh Boyer
-2021,MIA,2021_09_HOU_MIA,George Godsey,Josh Boyer
-2021,MIA,2021_10_BAL_MIA,George Godsey,Josh Boyer
-2021,MIA,2021_11_MIA_NYJ,George Godsey,Josh Boyer
-2021,MIA,2021_12_CAR_MIA,George Godsey,Josh Boyer
-2021,MIA,2021_13_NYG_MIA,George Godsey,Josh Boyer
-2021,MIA,2021_15_NYJ_MIA,George Godsey,Josh Boyer
-2021,MIA,2021_16_MIA_NO,George Godsey,Josh Boyer
-2021,MIA,2021_17_MIA_TEN,George Godsey,Josh Boyer
-2021,MIA,2021_18_NE_MIA,George Godsey,Josh Boyer
-2021,MIN,2021_01_MIN_CIN,Klint Kubiak,Mike Zimmer
-2021,MIN,2021_02_MIN_ARI,Klint Kubiak,Mike Zimmer
-2021,MIN,2021_03_SEA_MIN,Klint Kubiak,Mike Zimmer
-2021,MIN,2021_04_CLE_MIN,Klint Kubiak,Mike Zimmer
-2021,MIN,2021_05_DET_MIN,Klint Kubiak,Mike Zimmer
-2021,MIN,2021_06_MIN_CAR,Klint Kubiak,Mike Zimmer
-2021,MIN,2021_08_DAL_MIN,Klint Kubiak,Mike Zimmer
-2021,MIN,2021_09_MIN_BAL,Klint Kubiak,Mike Zimmer
-2021,MIN,2021_10_MIN_LAC,Klint Kubiak,Mike Zimmer
-2021,MIN,2021_11_GB_MIN,Klint Kubiak,Mike Zimmer
-2021,MIN,2021_12_MIN_SF,Klint Kubiak,Mike Zimmer
-2021,MIN,2021_13_MIN_DET,Klint Kubiak,Mike Zimmer
-2021,MIN,2021_14_PIT_MIN,Klint Kubiak,Mike Zimmer
-2021,MIN,2021_15_MIN_CHI,Klint Kubiak,Mike Zimmer
-2021,MIN,2021_16_LA_MIN,Klint Kubiak,Mike Zimmer
-2021,MIN,2021_17_MIN_GB,Klint Kubiak,Mike Zimmer
-2021,MIN,2021_18_CHI_MIN,Klint Kubiak,Mike Zimmer
-2021,NE,2021_01_MIA_NE,Josh McDaniels,Bill Belichick
-2021,NE,2021_02_NE_NYJ,Josh McDaniels,Bill Belichick
-2021,NE,2021_03_NO_NE,Josh McDaniels,Bill Belichick
-2021,NE,2021_04_TB_NE,Josh McDaniels,Bill Belichick
-2021,NE,2021_05_NE_HOU,Josh McDaniels,Bill Belichick
-2021,NE,2021_06_DAL_NE,Josh McDaniels,Bill Belichick
-2021,NE,2021_07_NYJ_NE,Josh McDaniels,Bill Belichick
-2021,NE,2021_08_NE_LAC,Josh McDaniels,Bill Belichick
-2021,NE,2021_09_NE_CAR,Josh McDaniels,Bill Belichick
-2021,NE,2021_10_CLE_NE,Josh McDaniels,Bill Belichick
-2021,NE,2021_11_NE_ATL,Josh McDaniels,Bill Belichick
-2021,NE,2021_12_TEN_NE,Josh McDaniels,Bill Belichick
-2021,NE,2021_13_NE_BUF,Josh McDaniels,Bill Belichick
-2021,NE,2021_15_NE_IND,Josh McDaniels,Bill Belichick
-2021,NE,2021_16_BUF_NE,Josh McDaniels,Bill Belichick
-2021,NE,2021_17_JAX_NE,Josh McDaniels,Bill Belichick
-2021,NE,2021_18_NE_MIA,Josh McDaniels,Bill Belichick
-2021,NE,2021_19_NE_BUF,Josh McDaniels,Bill Belichick
-2021,NO,2021_01_GB_NO,Sean Payton,Dennis Allen
-2021,NO,2021_02_NO_CAR,Sean Payton,Dennis Allen
-2021,NO,2021_03_NO_NE,Sean Payton,Dennis Allen
-2021,NO,2021_04_NYG_NO,Sean Payton,Dennis Allen
-2021,NO,2021_05_NO_WAS,Sean Payton,Dennis Allen
-2021,NO,2021_07_NO_SEA,Sean Payton,Dennis Allen
-2021,NO,2021_08_TB_NO,Sean Payton,Dennis Allen
-2021,NO,2021_09_ATL_NO,Sean Payton,Dennis Allen
-2021,NO,2021_10_NO_TEN,Sean Payton,Dennis Allen
-2021,NO,2021_11_NO_PHI,Sean Payton,Dennis Allen
-2021,NO,2021_12_BUF_NO,Sean Payton,Dennis Allen
-2021,NO,2021_13_DAL_NO,Sean Payton,Dennis Allen
-2021,NO,2021_14_NO_NYJ,Sean Payton,Dennis Allen
-2021,NO,2021_15_NO_TB,Sean Payton,Dennis Allen
-2021,NO,2021_16_MIA_NO,Sean Payton,Dennis Allen
-2021,NO,2021_17_CAR_NO,Sean Payton,Dennis Allen
-2021,NO,2021_18_NO_ATL,Sean Payton,Dennis Allen
-2021,NYG,2021_01_DEN_NYG,Jason Garrett,Patrick Graham
-2021,NYG,2021_02_NYG_WAS,Jason Garrett,Patrick Graham
-2021,NYG,2021_03_ATL_NYG,Jason Garrett,Patrick Graham
-2021,NYG,2021_04_NYG_NO,Jason Garrett,Patrick Graham
-2021,NYG,2021_05_NYG_DAL,Jason Garrett,Patrick Graham
-2021,NYG,2021_06_LA_NYG,Jason Garrett,Patrick Graham
-2021,NYG,2021_07_CAR_NYG,Jason Garrett,Patrick Graham
-2021,NYG,2021_08_NYG_KC,Jason Garrett,Patrick Graham
-2021,NYG,2021_09_LV_NYG,Jason Garrett,Patrick Graham
-2021,NYG,2021_11_NYG_TB,Jason Garrett,Patrick Graham
-2021,NYG,2021_12_PHI_NYG,Freddie Kitchens,Patrick Graham
-2021,NYG,2021_13_NYG_MIA,Freddie Kitchens,Patrick Graham
-2021,NYG,2021_14_NYG_LAC,Freddie Kitchens,Patrick Graham
-2021,NYG,2021_15_DAL_NYG,Freddie Kitchens,Patrick Graham
-2021,NYG,2021_16_NYG_PHI,Freddie Kitchens,Patrick Graham
-2021,NYG,2021_17_NYG_CHI,Freddie Kitchens,Patrick Graham
-2021,NYG,2021_18_WAS_NYG,Freddie Kitchens,Patrick Graham
-2021,NYJ,2021_01_NYJ_CAR,Mike LaFleur,Jeff Ulbrich
-2021,NYJ,2021_02_NE_NYJ,Mike LaFleur,Jeff Ulbrich
-2021,NYJ,2021_03_NYJ_DEN,Mike LaFleur,Jeff Ulbrich
-2021,NYJ,2021_04_TEN_NYJ,Mike LaFleur,Jeff Ulbrich
-2021,NYJ,2021_05_NYJ_ATL,Mike LaFleur,Jeff Ulbrich
-2021,NYJ,2021_07_NYJ_NE,Mike LaFleur,Jeff Ulbrich
-2021,NYJ,2021_08_CIN_NYJ,Mike LaFleur,Jeff Ulbrich
-2021,NYJ,2021_09_NYJ_IND,Mike LaFleur,Jeff Ulbrich
-2021,NYJ,2021_10_BUF_NYJ,Mike LaFleur,Jeff Ulbrich
-2021,NYJ,2021_11_MIA_NYJ,Mike LaFleur,Jeff Ulbrich
-2021,NYJ,2021_12_NYJ_HOU,Mike LaFleur,Jeff Ulbrich
-2021,NYJ,2021_13_PHI_NYJ,Mike LaFleur,Jeff Ulbrich
-2021,NYJ,2021_14_NO_NYJ,Mike LaFleur,Jeff Ulbrich
-2021,NYJ,2021_15_NYJ_MIA,Mike LaFleur,Jeff Ulbrich
-2021,NYJ,2021_16_JAX_NYJ,Mike LaFleur,Jeff Ulbrich
-2021,NYJ,2021_17_TB_NYJ,Mike LaFleur,Jeff Ulbrich
-2021,NYJ,2021_18_NYJ_BUF,Mike LaFleur,Jeff Ulbrich
-2021,PHI,2021_01_PHI_ATL,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_02_SF_PHI,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_03_PHI_DAL,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_04_KC_PHI,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_05_PHI_CAR,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_06_TB_PHI,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_07_PHI_LV,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_08_PHI_DET,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_09_LAC_PHI,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_10_PHI_DEN,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_11_NO_PHI,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_12_PHI_NYG,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_13_PHI_NYJ,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_15_WAS_PHI,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_16_NYG_PHI,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_17_PHI_WAS,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_18_DAL_PHI,Nick Sirianni,Jonathan Gannon
-2021,PHI,2021_19_PHI_TB,Nick Sirianni,Jonathan Gannon
-2021,PIT,2021_01_PIT_BUF,Matt Canada,Mike Tomlin
-2021,PIT,2021_02_LV_PIT,Matt Canada,Mike Tomlin
-2021,PIT,2021_03_CIN_PIT,Matt Canada,Mike Tomlin
-2021,PIT,2021_04_PIT_GB,Matt Canada,Mike Tomlin
-2021,PIT,2021_05_DEN_PIT,Matt Canada,Mike Tomlin
-2021,PIT,2021_06_SEA_PIT,Matt Canada,Mike Tomlin
-2021,PIT,2021_08_PIT_CLE,Matt Canada,Mike Tomlin
-2021,PIT,2021_09_CHI_PIT,Matt Canada,Mike Tomlin
-2021,PIT,2021_10_DET_PIT,Matt Canada,Mike Tomlin
-2021,PIT,2021_11_PIT_LAC,Matt Canada,Mike Tomlin
-2021,PIT,2021_12_PIT_CIN,Matt Canada,Mike Tomlin
-2021,PIT,2021_13_BAL_PIT,Matt Canada,Mike Tomlin
-2021,PIT,2021_14_PIT_MIN,Matt Canada,Mike Tomlin
-2021,PIT,2021_15_TEN_PIT,Matt Canada,Mike Tomlin
-2021,PIT,2021_16_PIT_KC,Matt Canada,Mike Tomlin
-2021,PIT,2021_17_CLE_PIT,Matt Canada,Mike Tomlin
-2021,PIT,2021_18_PIT_BAL,Matt Canada,Mike Tomlin
-2021,PIT,2021_19_PIT_KC,Matt Canada,Mike Tomlin
-2021,SEA,2021_01_SEA_IND,Shane Waldron,Ken Norton
-2021,SEA,2021_02_TEN_SEA,Shane Waldron,Ken Norton
-2021,SEA,2021_03_SEA_MIN,Shane Waldron,Ken Norton
-2021,SEA,2021_04_SEA_SF,Shane Waldron,Ken Norton
-2021,SEA,2021_05_LA_SEA,Shane Waldron,Ken Norton
-2021,SEA,2021_06_SEA_PIT,Shane Waldron,Ken Norton
-2021,SEA,2021_07_NO_SEA,Shane Waldron,Ken Norton
-2021,SEA,2021_08_JAX_SEA,Shane Waldron,Ken Norton
-2021,SEA,2021_10_SEA_GB,Shane Waldron,Ken Norton
-2021,SEA,2021_11_ARI_SEA,Shane Waldron,Ken Norton
-2021,SEA,2021_12_SEA_WAS,Shane Waldron,Ken Norton
-2021,SEA,2021_13_SF_SEA,Shane Waldron,Ken Norton
-2021,SEA,2021_14_SEA_HOU,Shane Waldron,Ken Norton
-2021,SEA,2021_15_SEA_LA,Shane Waldron,Ken Norton
-2021,SEA,2021_16_CHI_SEA,Shane Waldron,Ken Norton
-2021,SEA,2021_17_DET_SEA,Shane Waldron,Ken Norton
-2021,SEA,2021_18_SEA_ARI,Shane Waldron,Ken Norton
-2021,SF,2021_01_SF_DET,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_02_SF_PHI,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_03_GB_SF,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_04_SEA_SF,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_05_SF_ARI,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_07_IND_SF,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_08_SF_CHI,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_09_ARI_SF,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_10_LA_SF,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_11_SF_JAX,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_12_MIN_SF,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_13_SF_SEA,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_14_SF_CIN,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_15_ATL_SF,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_16_SF_TEN,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_17_HOU_SF,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_18_SF_LA,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_19_SF_DAL,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_20_SF_GB,Kyle Shanahan,DeMeco Ryans
-2021,SF,2021_21_SF_LA,Kyle Shanahan,DeMeco Ryans
-2021,TB,2021_01_DAL_TB,Byron Leftwich,Todd Bowles
-2021,TB,2021_02_ATL_TB,Byron Leftwich,Todd Bowles
-2021,TB,2021_03_TB_LA,Byron Leftwich,Todd Bowles
-2021,TB,2021_04_TB_NE,Byron Leftwich,Todd Bowles
-2021,TB,2021_05_MIA_TB,Byron Leftwich,Todd Bowles
-2021,TB,2021_06_TB_PHI,Byron Leftwich,Todd Bowles
-2021,TB,2021_07_CHI_TB,Byron Leftwich,Todd Bowles
-2021,TB,2021_08_TB_NO,Byron Leftwich,Todd Bowles
-2021,TB,2021_10_TB_WAS,Byron Leftwich,Todd Bowles
-2021,TB,2021_11_NYG_TB,Byron Leftwich,Todd Bowles
-2021,TB,2021_12_TB_IND,Byron Leftwich,Todd Bowles
-2021,TB,2021_13_TB_ATL,Byron Leftwich,Todd Bowles
-2021,TB,2021_14_BUF_TB,Byron Leftwich,Todd Bowles
-2021,TB,2021_15_NO_TB,Byron Leftwich,Todd Bowles
-2021,TB,2021_16_TB_CAR,Byron Leftwich,Todd Bowles
-2021,TB,2021_17_TB_NYJ,Byron Leftwich,Todd Bowles
-2021,TB,2021_18_CAR_TB,Byron Leftwich,Todd Bowles
-2021,TB,2021_19_PHI_TB,Byron Leftwich,Todd Bowles
-2021,TB,2021_20_LA_TB,Byron Leftwich,Todd Bowles
-2021,TEN,2021_01_ARI_TEN,Todd Downing,Shane Bowen
-2021,TEN,2021_02_TEN_SEA,Todd Downing,Shane Bowen
-2021,TEN,2021_03_IND_TEN,Todd Downing,Shane Bowen
-2021,TEN,2021_04_TEN_NYJ,Todd Downing,Shane Bowen
-2021,TEN,2021_05_TEN_JAX,Todd Downing,Shane Bowen
-2021,TEN,2021_06_BUF_TEN,Todd Downing,Shane Bowen
-2021,TEN,2021_07_KC_TEN,Todd Downing,Shane Bowen
-2021,TEN,2021_08_TEN_IND,Todd Downing,Shane Bowen
-2021,TEN,2021_09_TEN_LA,Todd Downing,Shane Bowen
-2021,TEN,2021_10_NO_TEN,Todd Downing,Shane Bowen
-2021,TEN,2021_11_HOU_TEN,Todd Downing,Shane Bowen
-2021,TEN,2021_12_TEN_NE,Todd Downing,Shane Bowen
-2021,TEN,2021_14_JAX_TEN,Todd Downing,Shane Bowen
-2021,TEN,2021_15_TEN_PIT,Todd Downing,Shane Bowen
-2021,TEN,2021_16_SF_TEN,Todd Downing,Shane Bowen
-2021,TEN,2021_17_MIA_TEN,Todd Downing,Shane Bowen
-2021,TEN,2021_18_TEN_HOU,Todd Downing,Shane Bowen
-2021,TEN,2021_20_CIN_TEN,Todd Downing,Shane Bowen
-2021,WAS,2021_01_LAC_WAS,Scott Turner,Jack Del Rio
-2021,WAS,2021_02_NYG_WAS,Scott Turner,Jack Del Rio
-2021,WAS,2021_03_WAS_BUF,Scott Turner,Jack Del Rio
-2021,WAS,2021_04_WAS_ATL,Scott Turner,Jack Del Rio
-2021,WAS,2021_05_NO_WAS,Scott Turner,Jack Del Rio
-2021,WAS,2021_06_KC_WAS,Scott Turner,Jack Del Rio
-2021,WAS,2021_07_WAS_GB,Scott Turner,Jack Del Rio
-2021,WAS,2021_08_WAS_DEN,Scott Turner,Jack Del Rio
-2021,WAS,2021_10_TB_WAS,Scott Turner,Jack Del Rio
-2021,WAS,2021_11_WAS_CAR,Scott Turner,Jack Del Rio
-2021,WAS,2021_12_SEA_WAS,Scott Turner,Jack Del Rio
-2021,WAS,2021_13_WAS_LV,Scott Turner,Jack Del Rio
-2021,WAS,2021_14_DAL_WAS,Scott Turner,Jack Del Rio
-2021,WAS,2021_15_WAS_PHI,Scott Turner,Jack Del Rio
-2021,WAS,2021_16_WAS_DAL,Scott Turner,Jack Del Rio
-2021,WAS,2021_17_PHI_WAS,Scott Turner,Jack Del Rio
-2021,WAS,2021_18_WAS_NYG,Scott Turner,Jack Del Rio
-2022,ARI,2022_01_KC_ARI,Kliff Kingsbury,Vance Joseph
-2022,ARI,2022_02_ARI_LV,Kliff Kingsbury,Vance Joseph
-2022,ARI,2022_03_LA_ARI,Kliff Kingsbury,Vance Joseph
-2022,ARI,2022_04_ARI_CAR,Kliff Kingsbury,Vance Joseph
-2022,ARI,2022_05_PHI_ARI,Kliff Kingsbury,Vance Joseph
-2022,ARI,2022_06_ARI_SEA,Kliff Kingsbury,Vance Joseph
-2022,ARI,2022_07_NO_ARI,Kliff Kingsbury,Vance Joseph
-2022,ARI,2022_08_ARI_MIN,Kliff Kingsbury,Vance Joseph
-2022,ARI,2022_09_SEA_ARI,Kliff Kingsbury,Vance Joseph
-2022,ARI,2022_10_ARI_LA,Kliff Kingsbury,Vance Joseph
-2022,ARI,2022_11_SF_ARI,Kliff Kingsbury,Vance Joseph
-2022,ARI,2022_12_LAC_ARI,Kliff Kingsbury,Vance Joseph
-2022,ARI,2022_14_NE_ARI,Kliff Kingsbury,Vance Joseph
-2022,ARI,2022_15_ARI_DEN,Kliff Kingsbury,Vance Joseph
-2022,ARI,2022_16_TB_ARI,Kliff Kingsbury,Vance Joseph
-2022,ARI,2022_17_ARI_ATL,Kliff Kingsbury,Vance Joseph
-2022,ARI,2022_18_ARI_SF,Kliff Kingsbury,Vance Joseph
-2022,ATL,2022_01_NO_ATL,Arthur Smith,Dean Pees
-2022,ATL,2022_02_ATL_LA,Arthur Smith,Dean Pees
-2022,ATL,2022_03_ATL_SEA,Arthur Smith,Dean Pees
-2022,ATL,2022_04_CLE_ATL,Arthur Smith,Dean Pees
-2022,ATL,2022_05_ATL_TB,Arthur Smith,Dean Pees
-2022,ATL,2022_06_SF_ATL,Arthur Smith,Dean Pees
-2022,ATL,2022_07_ATL_CIN,Arthur Smith,Dean Pees
-2022,ATL,2022_08_CAR_ATL,Arthur Smith,Dean Pees
-2022,ATL,2022_09_LAC_ATL,Arthur Smith,Dean Pees
-2022,ATL,2022_10_ATL_CAR,Arthur Smith,Dean Pees
-2022,ATL,2022_11_CHI_ATL,Arthur Smith,Dean Pees
-2022,ATL,2022_12_ATL_WAS,Arthur Smith,Dean Pees
-2022,ATL,2022_13_PIT_ATL,Arthur Smith,Dean Pees
-2022,ATL,2022_15_ATL_NO,Arthur Smith,Dean Pees
-2022,ATL,2022_16_ATL_BAL,Arthur Smith,Dean Pees
-2022,ATL,2022_17_ARI_ATL,Arthur Smith,Dean Pees
-2022,ATL,2022_18_TB_ATL,Arthur Smith,Dean Pees
-2022,BAL,2022_01_BAL_NYJ,Greg Roman,Mike Macdonald
-2022,BAL,2022_02_MIA_BAL,Greg Roman,Mike Macdonald
-2022,BAL,2022_03_BAL_NE,Greg Roman,Mike Macdonald
-2022,BAL,2022_04_BUF_BAL,Greg Roman,Mike Macdonald
-2022,BAL,2022_05_CIN_BAL,Greg Roman,Mike Macdonald
-2022,BAL,2022_06_BAL_NYG,Greg Roman,Mike Macdonald
-2022,BAL,2022_07_CLE_BAL,Greg Roman,Mike Macdonald
-2022,BAL,2022_08_BAL_TB,Greg Roman,Mike Macdonald
-2022,BAL,2022_09_BAL_NO,Greg Roman,Mike Macdonald
-2022,BAL,2022_11_CAR_BAL,Greg Roman,Mike Macdonald
-2022,BAL,2022_12_BAL_JAX,Greg Roman,Mike Macdonald
-2022,BAL,2022_13_DEN_BAL,Greg Roman,Mike Macdonald
-2022,BAL,2022_14_BAL_PIT,Greg Roman,Mike Macdonald
-2022,BAL,2022_15_BAL_CLE,Greg Roman,Mike Macdonald
-2022,BAL,2022_16_ATL_BAL,Greg Roman,Mike Macdonald
-2022,BAL,2022_17_PIT_BAL,Greg Roman,Mike Macdonald
-2022,BAL,2022_18_BAL_CIN,Greg Roman,Mike Macdonald
-2022,BAL,2022_19_BAL_CIN,Greg Roman,Mike Macdonald
-2022,BUF,2022_01_BUF_LA,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_02_TEN_BUF,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_03_BUF_MIA,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_04_BUF_BAL,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_05_PIT_BUF,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_06_BUF_KC,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_08_GB_BUF,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_09_BUF_NYJ,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_10_MIN_BUF,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_11_CLE_BUF,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_12_BUF_DET,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_13_BUF_NE,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_14_NYJ_BUF,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_15_MIA_BUF,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_16_BUF_CHI,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_18_NE_BUF,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_19_MIA_BUF,Ken Dorsey,Leslie Frazier
-2022,BUF,2022_20_CIN_BUF,Ken Dorsey,Leslie Frazier
-2022,CAR,2022_01_CLE_CAR,Matt Rhule,Phil Snow
-2022,CAR,2022_02_CAR_NYG,Matt Rhule,Phil Snow
-2022,CAR,2022_03_NO_CAR,Matt Rhule,Phil Snow
-2022,CAR,2022_04_ARI_CAR,Matt Rhule,Phil Snow
-2022,CAR,2022_05_SF_CAR,Matt Rhule,Phil Snow
-2022,CAR,2022_06_CAR_LA,Ben McAdoo,Al Holcomb
-2022,CAR,2022_07_TB_CAR,Ben McAdoo,Al Holcomb
-2022,CAR,2022_08_CAR_ATL,Ben McAdoo,Al Holcomb
-2022,CAR,2022_09_CAR_CIN,Ben McAdoo,Al Holcomb
-2022,CAR,2022_10_ATL_CAR,Ben McAdoo,Al Holcomb
-2022,CAR,2022_11_CAR_BAL,Ben McAdoo,Al Holcomb
-2022,CAR,2022_12_DEN_CAR,Ben McAdoo,Al Holcomb
-2022,CAR,2022_14_CAR_SEA,Ben McAdoo,Al Holcomb
-2022,CAR,2022_15_PIT_CAR,Ben McAdoo,Al Holcomb
-2022,CAR,2022_16_DET_CAR,Ben McAdoo,Al Holcomb
-2022,CAR,2022_17_CAR_TB,Ben McAdoo,Al Holcomb
-2022,CAR,2022_18_CAR_NO,Ben McAdoo,Al Holcomb
-2022,CHI,2022_01_SF_CHI,Luke Getsy,Alan Williams
-2022,CHI,2022_02_CHI_GB,Luke Getsy,Alan Williams
-2022,CHI,2022_03_HOU_CHI,Luke Getsy,Alan Williams
-2022,CHI,2022_04_CHI_NYG,Luke Getsy,Alan Williams
-2022,CHI,2022_05_CHI_MIN,Luke Getsy,Alan Williams
-2022,CHI,2022_06_WAS_CHI,Luke Getsy,Alan Williams
-2022,CHI,2022_07_CHI_NE,Luke Getsy,Alan Williams
-2022,CHI,2022_08_CHI_DAL,Luke Getsy,Alan Williams
-2022,CHI,2022_09_MIA_CHI,Luke Getsy,Alan Williams
-2022,CHI,2022_10_DET_CHI,Luke Getsy,Alan Williams
-2022,CHI,2022_11_CHI_ATL,Luke Getsy,Alan Williams
-2022,CHI,2022_12_CHI_NYJ,Luke Getsy,Alan Williams
-2022,CHI,2022_13_GB_CHI,Luke Getsy,Alan Williams
-2022,CHI,2022_15_PHI_CHI,Luke Getsy,Alan Williams
-2022,CHI,2022_16_BUF_CHI,Luke Getsy,Alan Williams
-2022,CHI,2022_17_CHI_DET,Luke Getsy,Alan Williams
-2022,CHI,2022_18_MIN_CHI,Luke Getsy,Alan Williams
-2022,CIN,2022_01_PIT_CIN,Zac Taylor,Lou Anarumo
-2022,CIN,2022_02_CIN_DAL,Zac Taylor,Lou Anarumo
-2022,CIN,2022_03_CIN_NYJ,Zac Taylor,Lou Anarumo
-2022,CIN,2022_04_MIA_CIN,Zac Taylor,Lou Anarumo
-2022,CIN,2022_05_CIN_BAL,Zac Taylor,Lou Anarumo
-2022,CIN,2022_06_CIN_NO,Zac Taylor,Lou Anarumo
-2022,CIN,2022_07_ATL_CIN,Zac Taylor,Lou Anarumo
-2022,CIN,2022_08_CIN_CLE,Zac Taylor,Lou Anarumo
-2022,CIN,2022_09_CAR_CIN,Zac Taylor,Lou Anarumo
-2022,CIN,2022_11_CIN_PIT,Zac Taylor,Lou Anarumo
-2022,CIN,2022_12_CIN_TEN,Zac Taylor,Lou Anarumo
-2022,CIN,2022_13_KC_CIN,Zac Taylor,Lou Anarumo
-2022,CIN,2022_14_CLE_CIN,Zac Taylor,Lou Anarumo
-2022,CIN,2022_15_CIN_TB,Zac Taylor,Lou Anarumo
-2022,CIN,2022_16_CIN_NE,Zac Taylor,Lou Anarumo
-2022,CIN,2022_18_BAL_CIN,Zac Taylor,Lou Anarumo
-2022,CIN,2022_19_BAL_CIN,Zac Taylor,Lou Anarumo
-2022,CIN,2022_20_CIN_BUF,Zac Taylor,Lou Anarumo
-2022,CIN,2022_21_CIN_KC,Zac Taylor,Lou Anarumo
-2022,CLE,2022_01_CLE_CAR,Kevin Stefanski,Joe Woods
-2022,CLE,2022_02_NYJ_CLE,Kevin Stefanski,Joe Woods
-2022,CLE,2022_03_PIT_CLE,Kevin Stefanski,Joe Woods
-2022,CLE,2022_04_CLE_ATL,Kevin Stefanski,Joe Woods
-2022,CLE,2022_05_LAC_CLE,Kevin Stefanski,Joe Woods
-2022,CLE,2022_06_NE_CLE,Kevin Stefanski,Joe Woods
-2022,CLE,2022_07_CLE_BAL,Kevin Stefanski,Joe Woods
-2022,CLE,2022_08_CIN_CLE,Kevin Stefanski,Joe Woods
-2022,CLE,2022_10_CLE_MIA,Kevin Stefanski,Joe Woods
-2022,CLE,2022_11_CLE_BUF,Kevin Stefanski,Joe Woods
-2022,CLE,2022_12_TB_CLE,Kevin Stefanski,Joe Woods
-2022,CLE,2022_13_CLE_HOU,Kevin Stefanski,Joe Woods
-2022,CLE,2022_14_CLE_CIN,Kevin Stefanski,Joe Woods
-2022,CLE,2022_15_BAL_CLE,Kevin Stefanski,Joe Woods
-2022,CLE,2022_16_NO_CLE,Kevin Stefanski,Joe Woods
-2022,CLE,2022_17_CLE_WAS,Kevin Stefanski,Joe Woods
-2022,CLE,2022_18_CLE_PIT,Kevin Stefanski,Joe Woods
-2022,DAL,2022_01_TB_DAL,Kellen Moore,Dan Quinn
-2022,DAL,2022_02_CIN_DAL,Kellen Moore,Dan Quinn
-2022,DAL,2022_03_DAL_NYG,Kellen Moore,Dan Quinn
-2022,DAL,2022_04_WAS_DAL,Kellen Moore,Dan Quinn
-2022,DAL,2022_05_DAL_LA,Kellen Moore,Dan Quinn
-2022,DAL,2022_06_DAL_PHI,Kellen Moore,Dan Quinn
-2022,DAL,2022_07_DET_DAL,Kellen Moore,Dan Quinn
-2022,DAL,2022_08_CHI_DAL,Kellen Moore,Dan Quinn
-2022,DAL,2022_10_DAL_GB,Kellen Moore,Dan Quinn
-2022,DAL,2022_11_DAL_MIN,Kellen Moore,Dan Quinn
-2022,DAL,2022_12_NYG_DAL,Kellen Moore,Dan Quinn
-2022,DAL,2022_13_IND_DAL,Kellen Moore,Dan Quinn
-2022,DAL,2022_14_HOU_DAL,Kellen Moore,Dan Quinn
-2022,DAL,2022_15_DAL_JAX,Kellen Moore,Dan Quinn
-2022,DAL,2022_16_PHI_DAL,Kellen Moore,Dan Quinn
-2022,DAL,2022_17_DAL_TEN,Kellen Moore,Dan Quinn
-2022,DAL,2022_18_DAL_WAS,Kellen Moore,Dan Quinn
-2022,DAL,2022_19_DAL_TB,Kellen Moore,Dan Quinn
-2022,DAL,2022_20_DAL_SF,Kellen Moore,Dan Quinn
-2022,DEN,2022_01_DEN_SEA,Nathaniel Hackett,Ejiro Evero
-2022,DEN,2022_02_HOU_DEN,Nathaniel Hackett,Ejiro Evero
-2022,DEN,2022_03_SF_DEN,Nathaniel Hackett,Ejiro Evero
-2022,DEN,2022_04_DEN_LV,Nathaniel Hackett,Ejiro Evero
-2022,DEN,2022_05_IND_DEN,Nathaniel Hackett,Ejiro Evero
-2022,DEN,2022_06_DEN_LAC,Nathaniel Hackett,Ejiro Evero
-2022,DEN,2022_07_NYJ_DEN,Nathaniel Hackett,Ejiro Evero
-2022,DEN,2022_08_DEN_JAX,Nathaniel Hackett,Ejiro Evero
-2022,DEN,2022_10_DEN_TEN,Nathaniel Hackett,Ejiro Evero
-2022,DEN,2022_11_LV_DEN,Klint Kubiak,Ejiro Evero
-2022,DEN,2022_12_DEN_CAR,Klint Kubiak,Ejiro Evero
-2022,DEN,2022_13_DEN_BAL,Klint Kubiak,Ejiro Evero
-2022,DEN,2022_14_KC_DEN,Klint Kubiak,Ejiro Evero
-2022,DEN,2022_15_ARI_DEN,Klint Kubiak,Ejiro Evero
-2022,DEN,2022_16_DEN_LA,Klint Kubiak,Ejiro Evero
-2022,DEN,2022_17_DEN_KC,Klint Kubiak,Ejiro Evero
-2022,DEN,2022_18_LAC_DEN,Klint Kubiak,Ejiro Evero
-2022,DET,2022_01_PHI_DET,Ben Johnson,Aaron Glenn
-2022,DET,2022_02_WAS_DET,Ben Johnson,Aaron Glenn
-2022,DET,2022_03_DET_MIN,Ben Johnson,Aaron Glenn
-2022,DET,2022_04_SEA_DET,Ben Johnson,Aaron Glenn
-2022,DET,2022_05_DET_NE,Ben Johnson,Aaron Glenn
-2022,DET,2022_07_DET_DAL,Ben Johnson,Aaron Glenn
-2022,DET,2022_08_MIA_DET,Ben Johnson,Aaron Glenn
-2022,DET,2022_09_GB_DET,Ben Johnson,Aaron Glenn
-2022,DET,2022_10_DET_CHI,Ben Johnson,Aaron Glenn
-2022,DET,2022_11_DET_NYG,Ben Johnson,Aaron Glenn
-2022,DET,2022_12_BUF_DET,Ben Johnson,Aaron Glenn
-2022,DET,2022_13_JAX_DET,Ben Johnson,Aaron Glenn
-2022,DET,2022_14_MIN_DET,Ben Johnson,Aaron Glenn
-2022,DET,2022_15_DET_NYJ,Ben Johnson,Aaron Glenn
-2022,DET,2022_16_DET_CAR,Ben Johnson,Aaron Glenn
-2022,DET,2022_17_CHI_DET,Ben Johnson,Aaron Glenn
-2022,DET,2022_18_DET_GB,Ben Johnson,Aaron Glenn
-2022,GB,2022_01_GB_MIN,Matt LaFleur,Joe Barry
-2022,GB,2022_02_CHI_GB,Matt LaFleur,Joe Barry
-2022,GB,2022_03_GB_TB,Matt LaFleur,Joe Barry
-2022,GB,2022_04_NE_GB,Matt LaFleur,Joe Barry
-2022,GB,2022_05_NYG_GB,Matt LaFleur,Joe Barry
-2022,GB,2022_06_NYJ_GB,Matt LaFleur,Joe Barry
-2022,GB,2022_07_GB_WAS,Matt LaFleur,Joe Barry
-2022,GB,2022_08_GB_BUF,Matt LaFleur,Joe Barry
-2022,GB,2022_09_GB_DET,Matt LaFleur,Joe Barry
-2022,GB,2022_10_DAL_GB,Matt LaFleur,Joe Barry
-2022,GB,2022_11_TEN_GB,Matt LaFleur,Joe Barry
-2022,GB,2022_12_GB_PHI,Matt LaFleur,Joe Barry
-2022,GB,2022_13_GB_CHI,Matt LaFleur,Joe Barry
-2022,GB,2022_15_LA_GB,Matt LaFleur,Joe Barry
-2022,GB,2022_16_GB_MIA,Matt LaFleur,Joe Barry
-2022,GB,2022_17_MIN_GB,Matt LaFleur,Joe Barry
-2022,GB,2022_18_DET_GB,Matt LaFleur,Joe Barry
-2022,HOU,2022_01_IND_HOU,Pep Hamilton,Lovie Smith
-2022,HOU,2022_02_HOU_DEN,Pep Hamilton,Lovie Smith
-2022,HOU,2022_03_HOU_CHI,Pep Hamilton,Lovie Smith
-2022,HOU,2022_04_LAC_HOU,Pep Hamilton,Lovie Smith
-2022,HOU,2022_05_HOU_JAX,Pep Hamilton,Lovie Smith
-2022,HOU,2022_07_HOU_LV,Pep Hamilton,Lovie Smith
-2022,HOU,2022_08_TEN_HOU,Pep Hamilton,Lovie Smith
-2022,HOU,2022_09_PHI_HOU,Pep Hamilton,Lovie Smith
-2022,HOU,2022_10_HOU_NYG,Pep Hamilton,Lovie Smith
-2022,HOU,2022_11_WAS_HOU,Pep Hamilton,Lovie Smith
-2022,HOU,2022_12_HOU_MIA,Pep Hamilton,Lovie Smith
-2022,HOU,2022_13_CLE_HOU,Pep Hamilton,Lovie Smith
-2022,HOU,2022_14_HOU_DAL,Pep Hamilton,Lovie Smith
-2022,HOU,2022_15_KC_HOU,Pep Hamilton,Lovie Smith
-2022,HOU,2022_16_HOU_TEN,Pep Hamilton,Lovie Smith
-2022,HOU,2022_17_JAX_HOU,Pep Hamilton,Lovie Smith
-2022,HOU,2022_18_HOU_IND,Pep Hamilton,Lovie Smith
-2022,IND,2022_01_IND_HOU,Frank Reich,Gus Bradley
-2022,IND,2022_02_IND_JAX,Frank Reich,Gus Bradley
-2022,IND,2022_03_KC_IND,Frank Reich,Gus Bradley
-2022,IND,2022_04_TEN_IND,Frank Reich,Gus Bradley
-2022,IND,2022_05_IND_DEN,Frank Reich,Gus Bradley
-2022,IND,2022_06_JAX_IND,Frank Reich,Gus Bradley
-2022,IND,2022_07_IND_TEN,Frank Reich,Gus Bradley
-2022,IND,2022_08_WAS_IND,Frank Reich,Gus Bradley
-2022,IND,2022_09_IND_NE,Frank Reich,Gus Bradley
-2022,IND,2022_10_IND_LV,Marcus Brady,Gus Bradley
-2022,IND,2022_11_PHI_IND,Marcus Brady,Gus Bradley
-2022,IND,2022_12_PIT_IND,Marcus Brady,Gus Bradley
-2022,IND,2022_13_IND_DAL,Marcus Brady,Gus Bradley
-2022,IND,2022_15_IND_MIN,Marcus Brady,Gus Bradley
-2022,IND,2022_16_LAC_IND,Marcus Brady,Gus Bradley
-2022,IND,2022_17_IND_NYG,Marcus Brady,Gus Bradley
-2022,IND,2022_18_HOU_IND,Marcus Brady,Gus Bradley
-2022,JAX,2022_01_JAX_WAS,Doug Pederson,Mike Caldwell
-2022,JAX,2022_02_IND_JAX,Doug Pederson,Mike Caldwell
-2022,JAX,2022_03_JAX_LAC,Doug Pederson,Mike Caldwell
-2022,JAX,2022_04_JAX_PHI,Doug Pederson,Mike Caldwell
-2022,JAX,2022_05_HOU_JAX,Doug Pederson,Mike Caldwell
-2022,JAX,2022_06_JAX_IND,Doug Pederson,Mike Caldwell
-2022,JAX,2022_07_NYG_JAX,Doug Pederson,Mike Caldwell
-2022,JAX,2022_08_DEN_JAX,Doug Pederson,Mike Caldwell
-2022,JAX,2022_09_LV_JAX,Doug Pederson,Mike Caldwell
-2022,JAX,2022_10_JAX_KC,Doug Pederson,Mike Caldwell
-2022,JAX,2022_12_BAL_JAX,Doug Pederson,Mike Caldwell
-2022,JAX,2022_13_JAX_DET,Doug Pederson,Mike Caldwell
-2022,JAX,2022_14_JAX_TEN,Doug Pederson,Mike Caldwell
-2022,JAX,2022_15_DAL_JAX,Doug Pederson,Mike Caldwell
-2022,JAX,2022_16_JAX_NYJ,Doug Pederson,Mike Caldwell
-2022,JAX,2022_17_JAX_HOU,Doug Pederson,Mike Caldwell
-2022,JAX,2022_18_TEN_JAX,Doug Pederson,Mike Caldwell
-2022,JAX,2022_19_LAC_JAX,Doug Pederson,Mike Caldwell
-2022,JAX,2022_20_JAX_KC,Doug Pederson,Mike Caldwell
 2022,KC,2022_01_KC_ARI,Andy Reid,Steve Spagnuolo
 2022,KC,2022_02_LAC_KC,Andy Reid,Steve Spagnuolo
 2022,KC,2022_03_KC_IND,Andy Reid,Steve Spagnuolo
@@ -8502,6 +6404,125 @@ season,team,game_id,off_play_caller,def_play_caller
 2023,KC,2023_16_LV_KC,Andy Reid,Steve Spagnuolo
 2023,KC,2023_17_CIN_KC,Andy Reid,Steve Spagnuolo
 2023,KC,2023_18_KC_LAC,Andy Reid,Steve Spagnuolo
+2013,LA,2013_01_ARI_STL,Brian Schottenheimer,Tim Walton
+2013,LA,2013_02_STL_ATL,Brian Schottenheimer,Tim Walton
+2013,LA,2013_03_STL_DAL,Brian Schottenheimer,Tim Walton
+2013,LA,2013_04_SF_STL,Brian Schottenheimer,Tim Walton
+2013,LA,2013_05_JAX_STL,Brian Schottenheimer,Tim Walton
+2013,LA,2013_06_STL_HOU,Brian Schottenheimer,Tim Walton
+2013,LA,2013_07_STL_CAR,Brian Schottenheimer,Tim Walton
+2013,LA,2013_08_SEA_STL,Brian Schottenheimer,Tim Walton
+2013,LA,2013_09_TEN_STL,Brian Schottenheimer,Tim Walton
+2013,LA,2013_10_STL_IND,Brian Schottenheimer,Tim Walton
+2013,LA,2013_12_CHI_STL,Brian Schottenheimer,Tim Walton
+2013,LA,2013_13_STL_SF,Brian Schottenheimer,Tim Walton
+2013,LA,2013_14_STL_ARI,Brian Schottenheimer,Tim Walton
+2013,LA,2013_15_NO_STL,Brian Schottenheimer,Tim Walton
+2013,LA,2013_16_TB_STL,Brian Schottenheimer,Tim Walton
+2013,LA,2013_17_STL_SEA,Brian Schottenheimer,Tim Walton
+2014,LA,2014_01_MIN_STL,Brian Schottenheimer,Gregg Williams
+2014,LA,2014_02_STL_TB,Brian Schottenheimer,Gregg Williams
+2014,LA,2014_03_DAL_STL,Brian Schottenheimer,Gregg Williams
+2014,LA,2014_05_STL_PHI,Brian Schottenheimer,Gregg Williams
+2014,LA,2014_06_SF_STL,Brian Schottenheimer,Gregg Williams
+2014,LA,2014_07_SEA_STL,Brian Schottenheimer,Gregg Williams
+2014,LA,2014_08_STL_KC,Brian Schottenheimer,Gregg Williams
+2014,LA,2014_09_STL_SF,Brian Schottenheimer,Gregg Williams
+2014,LA,2014_10_STL_ARI,Brian Schottenheimer,Gregg Williams
+2014,LA,2014_11_DEN_STL,Brian Schottenheimer,Gregg Williams
+2014,LA,2014_12_STL_SD,Brian Schottenheimer,Gregg Williams
+2014,LA,2014_13_OAK_STL,Brian Schottenheimer,Gregg Williams
+2014,LA,2014_14_STL_WAS,Brian Schottenheimer,Gregg Williams
+2014,LA,2014_15_ARI_STL,Brian Schottenheimer,Gregg Williams
+2014,LA,2014_16_NYG_STL,Brian Schottenheimer,Gregg Williams
+2014,LA,2014_17_STL_SEA,Brian Schottenheimer,Gregg Williams
+2015,LA,2015_01_SEA_STL,Rob Boras,Gregg Williams
+2015,LA,2015_02_STL_WAS,Rob Boras,Gregg Williams
+2015,LA,2015_03_PIT_STL,Rob Boras,Gregg Williams
+2015,LA,2015_04_STL_ARI,Rob Boras,Gregg Williams
+2015,LA,2015_05_STL_GB,Rob Boras,Gregg Williams
+2015,LA,2015_07_CLE_STL,Rob Boras,Gregg Williams
+2015,LA,2015_08_SF_STL,Rob Boras,Gregg Williams
+2015,LA,2015_09_STL_MIN,Rob Boras,Gregg Williams
+2015,LA,2015_10_CHI_STL,Rob Boras,Gregg Williams
+2015,LA,2015_11_STL_BAL,Rob Boras,Gregg Williams
+2015,LA,2015_12_STL_CIN,Rob Boras,Gregg Williams
+2015,LA,2015_13_ARI_STL,Rob Boras,Gregg Williams
+2015,LA,2015_14_DET_STL,Rob Boras,Gregg Williams
+2015,LA,2015_15_TB_STL,Rob Boras,Gregg Williams
+2015,LA,2015_16_STL_SEA,Rob Boras,Gregg Williams
+2015,LA,2015_17_STL_SF,Rob Boras,Gregg Williams
+2021,LA,2021_01_CHI_LA,Sean McVay,Raheem Morris
+2021,LA,2021_02_LA_IND,Sean McVay,Raheem Morris
+2021,LA,2021_03_TB_LA,Sean McVay,Raheem Morris
+2021,LA,2021_04_ARI_LA,Sean McVay,Raheem Morris
+2021,LA,2021_05_LA_SEA,Sean McVay,Raheem Morris
+2021,LA,2021_06_LA_NYG,Sean McVay,Raheem Morris
+2021,LA,2021_07_DET_LA,Sean McVay,Raheem Morris
+2021,LA,2021_08_LA_HOU,Sean McVay,Raheem Morris
+2021,LA,2021_09_TEN_LA,Sean McVay,Raheem Morris
+2021,LA,2021_10_LA_SF,Sean McVay,Raheem Morris
+2021,LA,2021_12_LA_GB,Sean McVay,Raheem Morris
+2021,LA,2021_13_JAX_LA,Sean McVay,Raheem Morris
+2021,LA,2021_14_LA_ARI,Sean McVay,Raheem Morris
+2021,LA,2021_15_SEA_LA,Sean McVay,Raheem Morris
+2021,LA,2021_16_LA_MIN,Sean McVay,Raheem Morris
+2021,LA,2021_17_LA_BAL,Sean McVay,Raheem Morris
+2021,LA,2021_18_SF_LA,Sean McVay,Raheem Morris
+2021,LA,2021_19_ARI_LA,Sean McVay,Raheem Morris
+2021,LA,2021_20_LA_TB,Sean McVay,Raheem Morris
+2021,LA,2021_21_SF_LA,Sean McVay,Raheem Morris
+2021,LA,2021_22_LA_CIN,Sean McVay,Raheem Morris
+2013,LAC,2013_01_HOU_SD,Ken Whisenhunt,John Pagano
+2013,LAC,2013_02_SD_PHI,Ken Whisenhunt,John Pagano
+2013,LAC,2013_03_SD_TEN,Ken Whisenhunt,John Pagano
+2013,LAC,2013_04_DAL_SD,Ken Whisenhunt,John Pagano
+2013,LAC,2013_05_SD_OAK,Ken Whisenhunt,John Pagano
+2013,LAC,2013_06_IND_SD,Ken Whisenhunt,John Pagano
+2013,LAC,2013_07_SD_JAX,Ken Whisenhunt,John Pagano
+2013,LAC,2013_09_SD_WAS,Ken Whisenhunt,John Pagano
+2013,LAC,2013_10_DEN_SD,Ken Whisenhunt,John Pagano
+2013,LAC,2013_11_SD_MIA,Ken Whisenhunt,John Pagano
+2013,LAC,2013_12_SD_KC,Ken Whisenhunt,John Pagano
+2013,LAC,2013_13_CIN_SD,Ken Whisenhunt,John Pagano
+2013,LAC,2013_14_NYG_SD,Ken Whisenhunt,John Pagano
+2013,LAC,2013_15_SD_DEN,Ken Whisenhunt,John Pagano
+2013,LAC,2013_16_OAK_SD,Ken Whisenhunt,John Pagano
+2013,LAC,2013_17_KC_SD,Ken Whisenhunt,John Pagano
+2013,LAC,2013_18_SD_CIN,Ken Whisenhunt,John Pagano
+2013,LAC,2013_19_SD_DEN,Ken Whisenhunt,John Pagano
+2014,LAC,2014_01_SD_ARI,Mike McCoy,John Pagano
+2014,LAC,2014_02_SEA_SD,Frank Reich,John Pagano
+2014,LAC,2014_03_SD_BUF,Frank Reich,John Pagano
+2014,LAC,2014_04_JAX_SD,Frank Reich,John Pagano
+2014,LAC,2014_05_NYJ_SD,Frank Reich,John Pagano
+2014,LAC,2014_06_SD_OAK,Frank Reich,John Pagano
+2014,LAC,2014_07_KC_SD,Frank Reich,John Pagano
+2014,LAC,2014_08_SD_DEN,Frank Reich,John Pagano
+2014,LAC,2014_09_SD_MIA,Frank Reich,John Pagano
+2014,LAC,2014_11_OAK_SD,Frank Reich,John Pagano
+2014,LAC,2014_12_STL_SD,Frank Reich,John Pagano
+2014,LAC,2014_13_SD_BAL,Frank Reich,John Pagano
+2014,LAC,2014_14_NE_SD,Frank Reich,John Pagano
+2014,LAC,2014_15_DEN_SD,Frank Reich,John Pagano
+2014,LAC,2014_16_SD_SF,Frank Reich,John Pagano
+2014,LAC,2014_17_SD_KC,Frank Reich,John Pagano
+2015,LAC,2015_01_DET_SD,Frank Reich,John Pagano
+2015,LAC,2015_02_SD_CIN,Frank Reich,John Pagano
+2015,LAC,2015_03_SD_MIN,Frank Reich,John Pagano
+2015,LAC,2015_04_CLE_SD,Frank Reich,John Pagano
+2015,LAC,2015_05_PIT_SD,Frank Reich,John Pagano
+2015,LAC,2015_06_SD_GB,Frank Reich,John Pagano
+2015,LAC,2015_07_OAK_SD,Frank Reich,John Pagano
+2015,LAC,2015_08_SD_BAL,Frank Reich,John Pagano
+2015,LAC,2015_09_CHI_SD,Frank Reich,John Pagano
+2015,LAC,2015_11_KC_SD,Frank Reich,John Pagano
+2015,LAC,2015_12_SD_JAX,Frank Reich,John Pagano
+2015,LAC,2015_13_DEN_SD,Frank Reich,John Pagano
+2015,LAC,2015_14_SD_KC,Frank Reich,John Pagano
+2015,LAC,2015_15_MIA_SD,Frank Reich,John Pagano
+2015,LAC,2015_16_SD_OAK,Frank Reich,John Pagano
+2015,LAC,2015_17_SD_DEN,Frank Reich,John Pagano
 2017,LAC,2017_01_LAC_DEN,Ken Whisenhunt,Gus Bradley
 2017,LAC,2017_02_MIA_LAC,Ken Whisenhunt,Gus Bradley
 2017,LAC,2017_03_KC_LAC,Ken Whisenhunt,Gus Bradley
@@ -8761,6 +6782,54 @@ season,team,game_id,off_play_caller,def_play_caller
 2023,LAR,2023_16_NO_LA,Sean McVay,Raheem Morris
 2023,LAR,2023_17_LA_NYG,Sean McVay,Raheem Morris
 2023,LAR,2023_18_LA_SF,Sean McVay,Raheem Morris
+2013,LV,2013_01_OAK_IND,Greg Olson,Jason Tarver
+2013,LV,2013_02_JAX_OAK,Greg Olson,Jason Tarver
+2013,LV,2013_03_OAK_DEN,Greg Olson,Jason Tarver
+2013,LV,2013_04_WAS_OAK,Greg Olson,Jason Tarver
+2013,LV,2013_05_SD_OAK,Greg Olson,Jason Tarver
+2013,LV,2013_06_OAK_KC,Greg Olson,Jason Tarver
+2013,LV,2013_08_PIT_OAK,Greg Olson,Jason Tarver
+2013,LV,2013_09_PHI_OAK,Greg Olson,Jason Tarver
+2013,LV,2013_10_OAK_NYG,Greg Olson,Jason Tarver
+2013,LV,2013_11_OAK_HOU,Greg Olson,Jason Tarver
+2013,LV,2013_12_TEN_OAK,Greg Olson,Jason Tarver
+2013,LV,2013_13_OAK_DAL,Greg Olson,Jason Tarver
+2013,LV,2013_14_OAK_NYJ,Greg Olson,Jason Tarver
+2013,LV,2013_15_KC_OAK,Greg Olson,Jason Tarver
+2013,LV,2013_16_OAK_SD,Greg Olson,Jason Tarver
+2013,LV,2013_17_DEN_OAK,Greg Olson,Jason Tarver
+2014,LV,2014_01_OAK_NYJ,Greg Olson,Jason Tarver
+2014,LV,2014_02_HOU_OAK,Greg Olson,Jason Tarver
+2014,LV,2014_03_OAK_NE,Greg Olson,Jason Tarver
+2014,LV,2014_04_MIA_OAK,Greg Olson,Jason Tarver
+2014,LV,2014_06_SD_OAK,Greg Olson,Jason Tarver
+2014,LV,2014_07_ARI_OAK,Greg Olson,Jason Tarver
+2014,LV,2014_08_OAK_CLE,Greg Olson,Jason Tarver
+2014,LV,2014_09_OAK_SEA,Greg Olson,Jason Tarver
+2014,LV,2014_10_DEN_OAK,Greg Olson,Jason Tarver
+2014,LV,2014_11_OAK_SD,Greg Olson,Jason Tarver
+2014,LV,2014_12_KC_OAK,Greg Olson,Jason Tarver
+2014,LV,2014_13_OAK_STL,Greg Olson,Jason Tarver
+2014,LV,2014_14_SF_OAK,Greg Olson,Jason Tarver
+2014,LV,2014_15_OAK_KC,Greg Olson,Jason Tarver
+2014,LV,2014_16_BUF_OAK,Greg Olson,Jason Tarver
+2014,LV,2014_17_OAK_DEN,Greg Olson,Jason Tarver
+2015,LV,2015_01_CIN_OAK,Greg Olson,Jason Tarver
+2015,LV,2015_02_BAL_OAK,Greg Olson,Jason Tarver
+2015,LV,2015_03_OAK_CLE,Greg Olson,Jason Tarver
+2015,LV,2015_04_OAK_CHI,Greg Olson,Jason Tarver
+2015,LV,2015_05_DEN_OAK,Greg Olson,Jason Tarver
+2015,LV,2015_07_OAK_SD,Greg Olson,Jason Tarver
+2015,LV,2015_08_NYJ_OAK,Greg Olson,Jason Tarver
+2015,LV,2015_09_OAK_PIT,Greg Olson,Jason Tarver
+2015,LV,2015_10_MIN_OAK,Greg Olson,Jason Tarver
+2015,LV,2015_11_OAK_DET,Greg Olson,Jason Tarver
+2015,LV,2015_12_OAK_TEN,Greg Olson,Jason Tarver
+2015,LV,2015_13_KC_OAK,Greg Olson,Jason Tarver
+2015,LV,2015_14_OAK_DEN,Greg Olson,Jason Tarver
+2015,LV,2015_15_GB_OAK,Greg Olson,Jason Tarver
+2015,LV,2015_16_SD_OAK,Greg Olson,Jason Tarver
+2015,LV,2015_17_OAK_KC,Greg Olson,Jason Tarver
 2020,LV,2020_01_LV_CAR,Jon Gruden,Paul Guenther
 2020,LV,2020_02_NO_LV,Jon Gruden,Paul Guenther
 2020,LV,2020_03_LV_NE,Jon Gruden,Paul Guenther
@@ -9642,6 +7711,79 @@ season,team,game_id,off_play_caller,def_play_caller
 2022,MIN,2022_17_MIN_GB,Kevin O'Connell,Ed Donatell
 2022,MIN,2022_18_MIN_CHI,Kevin O'Connell,Ed Donatell
 2022,MIN,2022_19_NYG_MIN,Kevin O'Connell,Ed Donatell
+2013,NE,2013_01_NE_BUF,Josh McDaniels,Matt Patricia
+2013,NE,2013_02_NYJ_NE,Josh McDaniels,Matt Patricia
+2013,NE,2013_03_TB_NE,Josh McDaniels,Matt Patricia
+2013,NE,2013_04_NE_ATL,Josh McDaniels,Matt Patricia
+2013,NE,2013_05_NE_CIN,Josh McDaniels,Matt Patricia
+2013,NE,2013_06_NO_NE,Josh McDaniels,Matt Patricia
+2013,NE,2013_07_NE_NYJ,Josh McDaniels,Matt Patricia
+2013,NE,2013_08_MIA_NE,Josh McDaniels,Matt Patricia
+2013,NE,2013_09_PIT_NE,Josh McDaniels,Matt Patricia
+2013,NE,2013_11_NE_CAR,Josh McDaniels,Matt Patricia
+2013,NE,2013_12_DEN_NE,Josh McDaniels,Matt Patricia
+2013,NE,2013_13_NE_HOU,Josh McDaniels,Matt Patricia
+2013,NE,2013_14_CLE_NE,Josh McDaniels,Matt Patricia
+2013,NE,2013_15_NE_MIA,Josh McDaniels,Matt Patricia
+2013,NE,2013_16_NE_BAL,Josh McDaniels,Matt Patricia
+2013,NE,2013_17_BUF_NE,Josh McDaniels,Matt Patricia
+2013,NE,2013_19_IND_NE,Josh McDaniels,Matt Patricia
+2013,NE,2013_20_NE_DEN,Josh McDaniels,Matt Patricia
+2014,NE,2014_01_NE_MIA,Josh McDaniels,Matt Patricia
+2014,NE,2014_02_NE_MIN,Josh McDaniels,Matt Patricia
+2014,NE,2014_03_OAK_NE,Josh McDaniels,Matt Patricia
+2014,NE,2014_04_NE_KC,Josh McDaniels,Matt Patricia
+2014,NE,2014_05_CIN_NE,Josh McDaniels,Matt Patricia
+2014,NE,2014_06_NE_BUF,Josh McDaniels,Matt Patricia
+2014,NE,2014_07_NYJ_NE,Josh McDaniels,Matt Patricia
+2014,NE,2014_08_CHI_NE,Josh McDaniels,Matt Patricia
+2014,NE,2014_09_DEN_NE,Josh McDaniels,Matt Patricia
+2014,NE,2014_11_NE_IND,Josh McDaniels,Matt Patricia
+2014,NE,2014_12_DET_NE,Josh McDaniels,Matt Patricia
+2014,NE,2014_13_NE_GB,Josh McDaniels,Matt Patricia
+2014,NE,2014_14_NE_SD,Josh McDaniels,Matt Patricia
+2014,NE,2014_15_MIA_NE,Josh McDaniels,Matt Patricia
+2014,NE,2014_16_NE_NYJ,Josh McDaniels,Matt Patricia
+2014,NE,2014_17_BUF_NE,Josh McDaniels,Matt Patricia
+2014,NE,2014_19_BAL_NE,Josh McDaniels,Matt Patricia
+2014,NE,2014_20_IND_NE,Josh McDaniels,Matt Patricia
+2014,NE,2014_21_NE_SEA,Josh McDaniels,Matt Patricia
+2015,NE,2015_01_PIT_NE,Josh McDaniels,Matt Patricia
+2015,NE,2015_02_NE_BUF,Josh McDaniels,Matt Patricia
+2015,NE,2015_03_JAX_NE,Josh McDaniels,Matt Patricia
+2015,NE,2015_05_NE_DAL,Josh McDaniels,Matt Patricia
+2015,NE,2015_06_NE_IND,Josh McDaniels,Matt Patricia
+2015,NE,2015_07_NYJ_NE,Josh McDaniels,Matt Patricia
+2015,NE,2015_08_MIA_NE,Josh McDaniels,Matt Patricia
+2015,NE,2015_09_WAS_NE,Josh McDaniels,Matt Patricia
+2015,NE,2015_10_NE_NYG,Josh McDaniels,Matt Patricia
+2015,NE,2015_11_BUF_NE,Josh McDaniels,Matt Patricia
+2015,NE,2015_12_NE_DEN,Josh McDaniels,Matt Patricia
+2015,NE,2015_13_PHI_NE,Josh McDaniels,Matt Patricia
+2015,NE,2015_14_NE_HOU,Josh McDaniels,Matt Patricia
+2015,NE,2015_15_TEN_NE,Josh McDaniels,Matt Patricia
+2015,NE,2015_16_NE_NYJ,Josh McDaniels,Matt Patricia
+2015,NE,2015_17_NE_MIA,Josh McDaniels,Matt Patricia
+2015,NE,2015_19_KC_NE,Josh McDaniels,Matt Patricia
+2015,NE,2015_20_NE_DEN,Josh McDaniels,Matt Patricia
+2021,NE,2021_01_MIA_NE,Josh McDaniels,Bill Belichick
+2021,NE,2021_02_NE_NYJ,Josh McDaniels,Bill Belichick
+2021,NE,2021_03_NO_NE,Josh McDaniels,Bill Belichick
+2021,NE,2021_04_TB_NE,Josh McDaniels,Bill Belichick
+2021,NE,2021_05_NE_HOU,Josh McDaniels,Bill Belichick
+2021,NE,2021_06_DAL_NE,Josh McDaniels,Bill Belichick
+2021,NE,2021_07_NYJ_NE,Josh McDaniels,Bill Belichick
+2021,NE,2021_08_NE_LAC,Josh McDaniels,Bill Belichick
+2021,NE,2021_09_NE_CAR,Josh McDaniels,Bill Belichick
+2021,NE,2021_10_CLE_NE,Josh McDaniels,Bill Belichick
+2021,NE,2021_11_NE_ATL,Josh McDaniels,Bill Belichick
+2021,NE,2021_12_TEN_NE,Josh McDaniels,Bill Belichick
+2021,NE,2021_13_NE_BUF,Josh McDaniels,Bill Belichick
+2021,NE,2021_15_NE_IND,Josh McDaniels,Bill Belichick
+2021,NE,2021_16_BUF_NE,Josh McDaniels,Bill Belichick
+2021,NE,2021_17_JAX_NE,Josh McDaniels,Bill Belichick
+2021,NE,2021_18_NE_MIA,Josh McDaniels,Bill Belichick
+2021,NE,2021_19_NE_BUF,Josh McDaniels,Bill Belichick
 2022,NE,2022_01_NE_MIA,Matt Patricia,Bill Belichick
 2022,NE,2022_02_NE_PIT,Matt Patricia,Bill Belichick
 2022,NE,2022_03_BAL_NE,Matt Patricia,Bill Belichick
@@ -9659,6 +7801,73 @@ season,team,game_id,off_play_caller,def_play_caller
 2022,NE,2022_16_CIN_NE,Matt Patricia,Bill Belichick
 2022,NE,2022_17_MIA_NE,Matt Patricia,Bill Belichick
 2022,NE,2022_18_NE_BUF,Matt Patricia,Bill Belichick
+2013,NO,2013_01_ATL_NO,Sean Payton,Rob Ryan
+2013,NO,2013_02_NO_TB,Sean Payton,Rob Ryan
+2013,NO,2013_03_ARI_NO,Sean Payton,Rob Ryan
+2013,NO,2013_04_MIA_NO,Sean Payton,Rob Ryan
+2013,NO,2013_05_NO_CHI,Sean Payton,Rob Ryan
+2013,NO,2013_06_NO_NE,Sean Payton,Rob Ryan
+2013,NO,2013_08_BUF_NO,Sean Payton,Rob Ryan
+2013,NO,2013_09_NO_NYJ,Sean Payton,Rob Ryan
+2013,NO,2013_10_DAL_NO,Sean Payton,Rob Ryan
+2013,NO,2013_11_SF_NO,Sean Payton,Rob Ryan
+2013,NO,2013_12_NO_ATL,Sean Payton,Rob Ryan
+2013,NO,2013_13_NO_SEA,Sean Payton,Rob Ryan
+2013,NO,2013_14_CAR_NO,Sean Payton,Rob Ryan
+2013,NO,2013_15_NO_STL,Sean Payton,Rob Ryan
+2013,NO,2013_16_NO_CAR,Sean Payton,Rob Ryan
+2013,NO,2013_17_TB_NO,Sean Payton,Rob Ryan
+2013,NO,2013_18_NO_PHI,Sean Payton,Rob Ryan
+2013,NO,2013_19_NO_SEA,Sean Payton,Rob Ryan
+2014,NO,2014_01_NO_ATL,Sean Payton,Rob Ryan
+2014,NO,2014_02_NO_CLE,Sean Payton,Rob Ryan
+2014,NO,2014_03_MIN_NO,Sean Payton,Rob Ryan
+2014,NO,2014_04_NO_DAL,Sean Payton,Rob Ryan
+2014,NO,2014_05_TB_NO,Sean Payton,Rob Ryan
+2014,NO,2014_07_NO_DET,Sean Payton,Rob Ryan
+2014,NO,2014_08_GB_NO,Sean Payton,Rob Ryan
+2014,NO,2014_09_NO_CAR,Sean Payton,Rob Ryan
+2014,NO,2014_10_SF_NO,Sean Payton,Rob Ryan
+2014,NO,2014_11_CIN_NO,Sean Payton,Rob Ryan
+2014,NO,2014_12_BAL_NO,Sean Payton,Rob Ryan
+2014,NO,2014_13_NO_PIT,Sean Payton,Rob Ryan
+2014,NO,2014_14_CAR_NO,Sean Payton,Rob Ryan
+2014,NO,2014_15_NO_CHI,Sean Payton,Rob Ryan
+2014,NO,2014_16_ATL_NO,Sean Payton,Rob Ryan
+2014,NO,2014_17_NO_TB,Sean Payton,Rob Ryan
+2015,NO,2015_01_NO_ARI,Sean Payton,Rob Ryan
+2015,NO,2015_02_TB_NO,Sean Payton,Rob Ryan
+2015,NO,2015_03_NO_CAR,Sean Payton,Rob Ryan
+2015,NO,2015_04_DAL_NO,Sean Payton,Rob Ryan
+2015,NO,2015_05_NO_PHI,Sean Payton,Rob Ryan
+2015,NO,2015_06_ATL_NO,Sean Payton,Rob Ryan
+2015,NO,2015_07_NO_IND,Sean Payton,Rob Ryan
+2015,NO,2015_08_NYG_NO,Sean Payton,Rob Ryan
+2015,NO,2015_09_TEN_NO,Sean Payton,Rob Ryan
+2015,NO,2015_10_NO_WAS,Sean Payton,Rob Ryan
+2015,NO,2015_12_NO_HOU,Sean Payton,Dennis Allen
+2015,NO,2015_13_CAR_NO,Sean Payton,Dennis Allen
+2015,NO,2015_14_NO_TB,Sean Payton,Dennis Allen
+2015,NO,2015_15_DET_NO,Sean Payton,Dennis Allen
+2015,NO,2015_16_JAX_NO,Sean Payton,Dennis Allen
+2015,NO,2015_17_NO_ATL,Sean Payton,Dennis Allen
+2021,NO,2021_01_GB_NO,Sean Payton,Dennis Allen
+2021,NO,2021_02_NO_CAR,Sean Payton,Dennis Allen
+2021,NO,2021_03_NO_NE,Sean Payton,Dennis Allen
+2021,NO,2021_04_NYG_NO,Sean Payton,Dennis Allen
+2021,NO,2021_05_NO_WAS,Sean Payton,Dennis Allen
+2021,NO,2021_07_NO_SEA,Sean Payton,Dennis Allen
+2021,NO,2021_08_TB_NO,Sean Payton,Dennis Allen
+2021,NO,2021_09_ATL_NO,Sean Payton,Dennis Allen
+2021,NO,2021_10_NO_TEN,Sean Payton,Dennis Allen
+2021,NO,2021_11_NO_PHI,Sean Payton,Dennis Allen
+2021,NO,2021_12_BUF_NO,Sean Payton,Dennis Allen
+2021,NO,2021_13_DAL_NO,Sean Payton,Dennis Allen
+2021,NO,2021_14_NO_NYJ,Sean Payton,Dennis Allen
+2021,NO,2021_15_NO_TB,Sean Payton,Dennis Allen
+2021,NO,2021_16_MIA_NO,Sean Payton,Dennis Allen
+2021,NO,2021_17_CAR_NO,Sean Payton,Dennis Allen
+2021,NO,2021_18_NO_ATL,Sean Payton,Dennis Allen
 2022,NO,2022_01_NO_ATL,Pete Carmichael,Dennis Allen
 2022,NO,2022_02_TB_NO,Pete Carmichael,Dennis Allen
 2022,NO,2022_03_NO_CAR,Pete Carmichael,Dennis Allen


### PR DESCRIPTION
- Updated the 2023 Panthers play caller data to reflect a 10/16/2023 change to the offensive play caller (source link: https://twitter.com/TomPelissero/status/1713957230314188899)
- Added play caller data for the 1999-2012 Atlanta Falcons