### PR TITLE
Updated the 2023 Raiders Coaching Information.

### DIFF
--- a/data/all_playcallers.csv
+++ b/data/all_playcallers.csv
@@ -6889,15 +6889,15 @@ season,team,game_id,off_play_caller,def_play_caller
 2023,LV,2023_06_NE_LV,Josh McDaniels,Patrick Graham
 2023,LV,2023_07_LV_CHI,Josh McDaniels,Patrick Graham
 2023,LV,2023_08_LV_DET,Josh McDaniels,Patrick Graham
-2023,LV,2023_09_NYG_LV,Josh McDaniels,Patrick Graham
-2023,LV,2023_10_NYJ_LV,Josh McDaniels,Patrick Graham
-2023,LV,2023_11_LV_MIA,Josh McDaniels,Patrick Graham
-2023,LV,2023_12_KC_LV,Josh McDaniels,Patrick Graham
-2023,LV,2023_14_MIN_LV,Josh McDaniels,Patrick Graham
-2023,LV,2023_15_LAC_LV,Josh McDaniels,Patrick Graham
-2023,LV,2023_16_LV_KC,Josh McDaniels,Patrick Graham
-2023,LV,2023_17_LV_IND,Josh McDaniels,Patrick Graham
-2023,LV,2023_18_DEN_LV,Josh McDaniels,Patrick Graham
+2023,LV,2023_09_NYG_LV,Bo Hardegree,Patrick Graham
+2023,LV,2023_10_NYJ_LV,Bo Hardegree,Patrick Graham
+2023,LV,2023_11_LV_MIA,Bo Hardegree,Patrick Graham
+2023,LV,2023_12_KC_LV,Bo Hardegree,Patrick Graham
+2023,LV,2023_14_MIN_LV,Bo Hardegree,Patrick Graham
+2023,LV,2023_15_LAC_LV,Bo Hardegree,Patrick Graham
+2023,LV,2023_16_LV_KC,Bo Hardegree,Patrick Graham
+2023,LV,2023_17_LV_IND,Bo Hardegree,Patrick Graham
+2023,LV,2023_18_DEN_LV,Bo Hardegree,Patrick Graham
 1999,MIA,1999_01_MIA_DEN,,
 1999,MIA,1999_02_ARI_MIA,,
 1999,MIA,1999_04_BUF_MIA,,


### PR DESCRIPTION
Updated the 2023 Las Vegas Raiders after multiple coaching changes that occurred between October 31st and November 1st of 2023.

Sources:
- https://twitter.com/RapSheet/status/1719653078289297754
- https://twitter.com/AlbertBreer/status/1719717491272769729
- https://twitter.com/RapSheet/status/1719727997224116680