### PR TITLE
Updated the 2023 Panthers

### DIFF
--- a/data/all_playcallers.csv
+++ b/data/all_playcallers.csv
@@ -1852,14 +1852,14 @@ season,team,game_id,off_play_caller,def_play_caller
 2023,CAR,2023_08_HOU_CAR,Thomas Brown,Eiro Evero
 2023,CAR,2023_09_IND_CAR,Thomas Brown,Eiro Evero
 2023,CAR,2023_10_CAR_CHI,Thomas Brown,Eiro Evero
-2023,CAR,2023_11_DAL_CAR,Thomas Brown,Eiro Evero
-2023,CAR,2023_12_CAR_TEN,Thomas Brown,Eiro Evero
-2023,CAR,2023_13_CAR_TB,Thomas Brown,Eiro Evero
-2023,CAR,2023_14_CAR_NO,Thomas Brown,Eiro Evero
-2023,CAR,2023_15_ATL_CAR,Thomas Brown,Eiro Evero
-2023,CAR,2023_16_GB_CAR,Thomas Brown,Eiro Evero
-2023,CAR,2023_17_CAR_JAX,Thomas Brown,Eiro Evero
-2023,CAR,2023_18_TB_CAR,Thomas Brown,Eiro Evero
+2023,CAR,2023_11_DAL_CAR,Frank Reich,Eiro Evero
+2023,CAR,2023_12_CAR_TEN,Frank Reich,Eiro Evero
+2023,CAR,2023_13_CAR_TB,Frank Reich,Eiro Evero
+2023,CAR,2023_14_CAR_NO,Frank Reich,Eiro Evero
+2023,CAR,2023_15_ATL_CAR,Frank Reich,Eiro Evero
+2023,CAR,2023_16_GB_CAR,Frank Reich,Eiro Evero
+2023,CAR,2023_17_CAR_JAX,Frank Reich,Eiro Evero
+2023,CAR,2023_18_TB_CAR,Frank Reich,Eiro Evero
 1999,CHI,1999_01_KC_CHI,,
 1999,CHI,1999_02_SEA_CHI,,
 1999,CHI,1999_03_CHI_OAK,,


### PR DESCRIPTION
Updated the 2023 following a reversal of a 10/16/2023 decision regarding the offensive play caller. Source: https://twitter.com/AdamSchefter/status/1724885784325501074